### PR TITLE
[Sprint 124] IFS-4577 PortierungVonStandardsInEntkoppeltenBaustein

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - `ISY-305`: Implementierung von IsySecurityTokenUtil zum Auslesen von Attributen aus dem Bearer Token
 - `ISY-980`: Anpassung der Dokumentation aufgrund von Security-Umstellungen
+- `IFS-2804`: Entfernen der `@EnableMethodSecurity` Annotation von `IsySecurityAutoConfiguration`
+  - Die Annotation muss in der Anwendung selbst gesetzt werden um Method Security zu aktivieren
 
 # 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - `ISY-980`: Anpassung der Dokumentation aufgrund von Security-Umstellungen
 - `IFS-2804`: Entfernen der `@EnableMethodSecurity` Annotation von `IsySecurityAutoConfiguration`
   - Die Annotation muss in der Anwendung selbst gesetzt werden um Method Security zu aktivieren
+- `IFS-3833`: Implementierung von Multi-Tenanacy-Support
 
 # 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - `ISY-305`: Implementierung von IsySecurityTokenUtil zum Auslesen von Attributen aus dem Bearer Token
 - `ISY-980`: Anpassung der Dokumentation aufgrund von Security-Umstellungen
+- `IFS-2248`: Bereitstellen von Funktionalität zur Token-Gültigkeitsüberprüfung und erneuten Authentifizierung
 - `IFS-2804`: Entfernen der `@EnableMethodSecurity` Annotation von `IsySecurityAutoConfiguration`
   - Die Annotation muss in der Anwendung selbst gesetzt werden um Method Security zu aktivieren
 - `IFS-3833`: Implementierung von Multi-Tenanacy-Support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.0
+
+- `IFS-4577`: Portierung fehlender Tickets aus isyfact-standards
+
 # 4.0.0
 
 - `ISY-305`: Implementierung von IsySecurityTokenUtil zum Auslesen von Attributen aus dem Bearer Token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `IFS-2804`: Entfernen der `@EnableMethodSecurity` Annotation von `IsySecurityAutoConfiguration`
   - Die Annotation muss in der Anwendung selbst gesetzt werden um Method Security zu aktivieren
 - `IFS-3833`: Implementierung von Multi-Tenanacy-Support
+- `IFS-4248`: Hinzufügen einer Klasse `ClaimsOnlyOAuth2AuthenticationToken`, welche innerhalb einer Anwendung verwendet werden kann, um Metadaten (bspw. der Name eines laufenden Batches) über den SecurityContext auszutauschen
 
 # 3.0.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,18 @@
+# Isy-Security
+
+## 5.0.0
+### Hinweise & bekannte Probleme
+- keine
+
+### Umgesetzte Tickets
+- `IFS-4577`: Portierung fehlender Tickets aus isyfact-standards
+
+#### Bug Fixes
+- keine
+
+#### Interne Anpassungen
+- keine
+
+### Durchzuführende Aktionen vor dem ersten Einsatz
+- keine
+

--- a/docs/modules/ROOT/pages/nutzungsvorgaben/inhalt.adoc
+++ b/docs/modules/ROOT/pages/nutzungsvorgaben/inhalt.adoc
@@ -378,6 +378,13 @@ public class OAuth2ServerSecurityConfig {
 }
 ----
 
+[INFO]
+====
+Bei der Verwendung von `isy-sicherheit` wurde der CSRF-Filter von Spring Security in vielen Fällen standarmäßig deaktiviert.
+Damit die von der Anwendung bereitgestellten Schnittstellen weiterhin ohne Probleme erreicht werden können, muss dieser mglw. durch entsprechende Konfiguration der `SecurityFilterChain` wieder deaktiviert werden: `http.csrf().disable()`.
+Dies soll nur falls absolut notwendig durchgeführt werden, um die Angriffsfläche der Anwendung nicht zu vergrößern.
+====
+
 [[konfigurationsparameterservice]]
 === Konfigurationsparameter
 

--- a/src/main/java/de/bund/bva/isyfact/security/authentication/ClaimsOnlyOAuth2AuthenticationToken.java
+++ b/src/main/java/de/bund/bva/isyfact/security/authentication/ClaimsOnlyOAuth2AuthenticationToken.java
@@ -1,0 +1,53 @@
+package de.bund.bva.isyfact.security.authentication;
+
+import java.util.Map;
+
+import org.springframework.security.core.Transient;
+import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
+
+/**
+ * An implementation of an {@link AbstractOAuth2TokenAuthenticationToken} that only contains token attributes (claims)
+ * and is by definition never authenticated.
+ */
+@Transient
+public final class ClaimsOnlyOAuth2AuthenticationToken extends AbstractOAuth2TokenAuthenticationToken<ClaimsOnlyOAuth2Token> {
+
+    /** The principal name which is the subject claim of the token. */
+    private final String principal;
+
+    /**
+     * Constructs a {@code ClaimsOnlyOAuth2AuthenticationToken} using the provided token.
+     *
+     * @param oauth2Token
+     *         the {@link ClaimsOnlyOAuth2Token} to use
+     */
+    public ClaimsOnlyOAuth2AuthenticationToken(ClaimsOnlyOAuth2Token oauth2Token) {
+        super(oauth2Token);
+        principal = oauth2Token.getSubject();
+    }
+
+    /**
+     * The principal name which is the subject claim of the token.
+     *
+     * @return the principal name
+     */
+    @Override
+    public String getPrincipal() {
+        return principal;
+    }
+
+    /**
+     * Always returns {@code false} because this token does not contain any granted authorities.
+     *
+     * @return {@code false}
+     */
+    @Override
+    public boolean isAuthenticated() {
+        return false;
+    }
+
+    @Override
+    public Map<String, Object> getTokenAttributes() {
+        return getToken().getClaims();
+    }
+}

--- a/src/main/java/de/bund/bva/isyfact/security/authentication/ClaimsOnlyOAuth2Token.java
+++ b/src/main/java/de/bund/bva/isyfact/security/authentication/ClaimsOnlyOAuth2Token.java
@@ -16,7 +16,7 @@ import de.bund.bva.isyfact.security.oauth2.util.IsySecurityTokenUtil;
 
 /**
  * An implementation of an {@link AbstractOAuth2Token} that contains only the claims of a JSON Web Token (JWT)
- * and no actual token value that could be used as for example a bearer token.
+ * and no actual token value that could be used, for example, as a bearer token.
  * <p>
  * This token is only intended for internal use within an application where it is assured that the application
  * will either not communicate with external systems or perform a proper authentication which overwrites this
@@ -101,7 +101,7 @@ public class ClaimsOnlyOAuth2Token extends AbstractOAuth2Token implements ClaimA
             claims.put(StandardClaimNames.SUB, subject);
             // Treat this as a token that has all claims easily accessible via IsySecurityTokenUtil already set,
             // similar to an empty AufrufKontext where the initial values are empty strings.
-            // Do this here instead of in build() so the keys can be overwritten with null (if desired).
+            // This approach allows the keys to be initialized with empty strings so that they can be overwritten with null (if desired).
             claims.put(IsySecurityTokenClaimNames.LOGIN, "");
             claims.put(IsySecurityTokenClaimNames.USER_ID, "");
             claims.put(IsySecurityTokenClaimNames.BHKNZ, "");

--- a/src/main/java/de/bund/bva/isyfact/security/authentication/ClaimsOnlyOAuth2Token.java
+++ b/src/main/java/de/bund/bva/isyfact/security/authentication/ClaimsOnlyOAuth2Token.java
@@ -11,6 +11,7 @@ import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.util.Assert;
 
+import de.bund.bva.isyfact.security.oauth2.util.IsySecurityTokenClaimNames;
 import de.bund.bva.isyfact.security.oauth2.util.IsySecurityTokenUtil;
 
 /**
@@ -44,22 +45,22 @@ public class ClaimsOnlyOAuth2Token extends AbstractOAuth2Token implements ClaimA
 
     @Nullable
     public String getLogin() {
-        return getClaimAsString(IsySecurityTokenUtil.LOGIN);
+        return getClaimAsString(IsySecurityTokenClaimNames.LOGIN);
     }
 
     @Nullable
     public String getUserId() {
-        return getClaimAsString(IsySecurityTokenUtil.USER_ID);
+        return getClaimAsString(IsySecurityTokenClaimNames.USER_ID);
     }
 
     @Nullable
     public String getBhknz() {
-        return getClaimAsString(IsySecurityTokenUtil.BHKNZ);
+        return getClaimAsString(IsySecurityTokenClaimNames.BHKNZ);
     }
 
     @Nullable
     public String getDisplayName() {
-        return getClaimAsString(IsySecurityTokenUtil.DISPLAY_NAME);
+        return getClaimAsString(IsySecurityTokenClaimNames.DISPLAY_NAME);
     }
 
     @Override
@@ -101,10 +102,10 @@ public class ClaimsOnlyOAuth2Token extends AbstractOAuth2Token implements ClaimA
             // Treat this as a token that has all claims easily accessible via IsySecurityTokenUtil already set,
             // similar to an empty AufrufKontext where the initial values are empty strings.
             // Do this here instead of in build() so the keys can be overwritten with null (if desired).
-            claims.put(IsySecurityTokenUtil.LOGIN, "");
-            claims.put(IsySecurityTokenUtil.USER_ID, "");
-            claims.put(IsySecurityTokenUtil.BHKNZ, "");
-            claims.put(IsySecurityTokenUtil.DISPLAY_NAME, "");
+            claims.put(IsySecurityTokenClaimNames.LOGIN, "");
+            claims.put(IsySecurityTokenClaimNames.USER_ID, "");
+            claims.put(IsySecurityTokenClaimNames.BHKNZ, "");
+            claims.put(IsySecurityTokenClaimNames.DISPLAY_NAME, "");
         }
 
         /**
@@ -116,7 +117,7 @@ public class ClaimsOnlyOAuth2Token extends AbstractOAuth2Token implements ClaimA
          * @return the {@link Builder} for further configurations
          */
         public Builder login(String login) {
-            claims.put(IsySecurityTokenUtil.LOGIN, login);
+            claims.put(IsySecurityTokenClaimNames.LOGIN, login);
             return this;
         }
 
@@ -129,7 +130,7 @@ public class ClaimsOnlyOAuth2Token extends AbstractOAuth2Token implements ClaimA
          * @return the {@link Builder} for further configurations
          */
         public Builder userId(String userId) {
-            claims.put(IsySecurityTokenUtil.USER_ID, userId);
+            claims.put(IsySecurityTokenClaimNames.USER_ID, userId);
             return this;
         }
 
@@ -142,7 +143,7 @@ public class ClaimsOnlyOAuth2Token extends AbstractOAuth2Token implements ClaimA
          * @return the {@link Builder} for further configurations
          */
         public Builder bhknz(String bhknz) {
-            claims.put(IsySecurityTokenUtil.BHKNZ, bhknz);
+            claims.put(IsySecurityTokenClaimNames.BHKNZ, bhknz);
             return this;
         }
 
@@ -155,7 +156,7 @@ public class ClaimsOnlyOAuth2Token extends AbstractOAuth2Token implements ClaimA
          * @return the {@link Builder} for further configurations
          */
         public Builder displayName(String displayName) {
-            claims.put(IsySecurityTokenUtil.DISPLAY_NAME, displayName);
+            claims.put(IsySecurityTokenClaimNames.DISPLAY_NAME, displayName);
             return this;
         }
 

--- a/src/main/java/de/bund/bva/isyfact/security/authentication/ClaimsOnlyOAuth2Token.java
+++ b/src/main/java/de/bund/bva/isyfact/security/authentication/ClaimsOnlyOAuth2Token.java
@@ -1,0 +1,180 @@
+package de.bund.bva.isyfact.security.authentication;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.lang.Nullable;
+import org.springframework.security.oauth2.core.AbstractOAuth2Token;
+import org.springframework.security.oauth2.core.ClaimAccessor;
+import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.util.Assert;
+
+import de.bund.bva.isyfact.security.oauth2.util.IsySecurityTokenUtil;
+
+/**
+ * An implementation of an {@link AbstractOAuth2Token} that contains only the claims of a JSON Web Token (JWT)
+ * and no actual token value that could be used as for example a bearer token.
+ * <p>
+ * This token is only intended for internal use within an application where it is assured that the application
+ * will either not communicate with external systems or perform a proper authentication which overwrites this
+ * token before doing so.
+ */
+public class ClaimsOnlyOAuth2Token extends AbstractOAuth2Token implements ClaimAccessor {
+
+    /** Map of the token claims. */
+    private final Map<String, Object> claims;
+
+    public ClaimsOnlyOAuth2Token(Map<String, Object> claims) {
+        super("dummy value that should never be returned");
+        Assert.notEmpty(claims, "claims cannot be empty");
+        this.claims = Collections.unmodifiableMap(new LinkedHashMap<>(claims));
+    }
+
+    /**
+     * Returns the Subject {@code (sub)} claim which identifies the principal that is the
+     * subject of the JWT.
+     *
+     * @return the Subject identifier
+     */
+    public String getSubject() {
+        return getClaimAsString(StandardClaimNames.SUB);
+    }
+
+    @Nullable
+    public String getLogin() {
+        return getClaimAsString(IsySecurityTokenUtil.LOGIN);
+    }
+
+    @Nullable
+    public String getUserId() {
+        return getClaimAsString(IsySecurityTokenUtil.USER_ID);
+    }
+
+    @Nullable
+    public String getBhknz() {
+        return getClaimAsString(IsySecurityTokenUtil.BHKNZ);
+    }
+
+    @Nullable
+    public String getDisplayName() {
+        return getClaimAsString(IsySecurityTokenUtil.DISPLAY_NAME);
+    }
+
+    @Override
+    public Map<String, Object> getClaims() {
+        return claims;
+    }
+
+    @Override
+    public String getTokenValue() {
+        throw new RuntimeException("This is an unauthenticated token that does not have a token value. "
+                + "It is only to be used in, for example an unauthenticated batch or task, for storing user data "
+                + "in claims for logging purposes. If you see this error it means the application likely tried "
+                + "to pass the token as part of a request to another application and you should instead make sure "
+                + "to perform a proper authentication.");
+    }
+
+    public ClaimsOnlyOAuth2AuthenticationToken asAuthentication() {
+        return new ClaimsOnlyOAuth2AuthenticationToken(this);
+    }
+
+    /**
+     * Return a {@link Builder} with the given subject set.
+     *
+     * @param subject
+     *         the value to use for the Subject {@code (sub)} claim
+     * @return a {@link Builder}
+     */
+    public static Builder withSubject(String subject) {
+        return new Builder(subject);
+    }
+
+    public static final class Builder {
+
+        /** The actual JWT builder. */
+        private final Map<String, Object> claims = new LinkedHashMap<>();
+
+        private Builder(String subject) {
+            claims.put(StandardClaimNames.SUB, subject);
+            // Treat this as a token that has all claims easily accessible via IsySecurityTokenUtil already set,
+            // similar to an empty AufrufKontext where the initial values are empty strings.
+            // Do this here instead of in build() so the keys can be overwritten with null (if desired).
+            claims.put(IsySecurityTokenUtil.LOGIN, "");
+            claims.put(IsySecurityTokenUtil.USER_ID, "");
+            claims.put(IsySecurityTokenUtil.BHKNZ, "");
+            claims.put(IsySecurityTokenUtil.DISPLAY_NAME, "");
+        }
+
+        /**
+         * Use this login in the resulting {@link Jwt}.
+         * It will be set in a claim that can be fetched by {@link IsySecurityTokenUtil#getLogin()}.
+         *
+         * @param login
+         *         the login to use
+         * @return the {@link Builder} for further configurations
+         */
+        public Builder login(String login) {
+            claims.put(IsySecurityTokenUtil.LOGIN, login);
+            return this;
+        }
+
+        /**
+         * Use this user ID in the resulting {@link Jwt}.
+         * It will be set in a claim that can be fetched by {@link IsySecurityTokenUtil#getUserId()}.
+         *
+         * @param userId
+         *         the user ID to use
+         * @return the {@link Builder} for further configurations
+         */
+        public Builder userId(String userId) {
+            claims.put(IsySecurityTokenUtil.USER_ID, userId);
+            return this;
+        }
+
+        /**
+         * Use this BHKNZ in the resulting {@link Jwt}.
+         * It will be set in a claim that can be fetched by {@link IsySecurityTokenUtil#getBhknz()}.
+         *
+         * @param bhknz
+         *         the BHKNZ to use
+         * @return the {@link Builder} for further configurations
+         */
+        public Builder bhknz(String bhknz) {
+            claims.put(IsySecurityTokenUtil.BHKNZ, bhknz);
+            return this;
+        }
+
+        /**
+         * Use this display name in the resulting {@link Jwt}.
+         * It will be set in a claim that can be fetched by {@link IsySecurityTokenUtil#getDisplayName()}.
+         *
+         * @param displayName
+         *         the display name to use
+         * @return the {@link Builder} for further configurations
+         */
+        public Builder displayName(String displayName) {
+            claims.put(IsySecurityTokenUtil.DISPLAY_NAME, displayName);
+            return this;
+        }
+
+        /**
+         * Use this claim in the resulting {@link Jwt}.
+         *
+         * @param name
+         *         the claim name
+         * @param value
+         *         the claim value
+         * @return the {@link Builder} for further configurations
+         */
+        public Builder claim(String name, Object value) {
+            claims.put(name, value);
+            return this;
+        }
+
+        public ClaimsOnlyOAuth2Token build() {
+            return new ClaimsOnlyOAuth2Token(claims);
+        }
+    }
+}

--- a/src/main/java/de/bund/bva/isyfact/security/autoconfigure/IsySecurityAutoConfiguration.java
+++ b/src/main/java/de/bund/bva/isyfact/security/autoconfigure/IsySecurityAutoConfiguration.java
@@ -7,7 +7,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.lang.Nullable;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.core.GrantedAuthorityDefaults;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
@@ -27,7 +26,6 @@ import de.bund.bva.isyfact.security.xmlparser.RolePrivilegesMapper;
 @ConditionalOnClass(EnableWebSecurity.class)
 @AutoConfiguration
 @EnableConfigurationProperties
-@EnableGlobalMethodSecurity(securedEnabled = true)
 public class IsySecurityAutoConfiguration {
 
     @Bean

--- a/src/main/java/de/bund/bva/isyfact/security/autoconfigure/IsySecurityAutoConfiguration.java
+++ b/src/main/java/de/bund/bva/isyfact/security/autoconfigure/IsySecurityAutoConfiguration.java
@@ -3,20 +3,38 @@ package de.bund.bva.isyfact.security.autoconfigure;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.lang.Nullable;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.core.GrantedAuthorityDefaults;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import com.nimbusds.jwt.proc.JWTProcessor;
+
 import de.bund.bva.isyfact.security.authentication.RolePrivilegeGrantedAuthoritiesConverter;
+import de.bund.bva.isyfact.security.condition.TenantsNotEmptyCondition;
 import de.bund.bva.isyfact.security.config.IsySecurityConfigurationProperties;
+import de.bund.bva.isyfact.security.config.JWTConfigurationProperties;
 import de.bund.bva.isyfact.security.core.Berechtigungsmanager;
 import de.bund.bva.isyfact.security.core.IsyOAuth2Berechtigungsmanager;
 import de.bund.bva.isyfact.security.core.IsyOAuth2Security;
 import de.bund.bva.isyfact.security.core.Security;
+import de.bund.bva.isyfact.security.core.TenantJwsKeySelector;
+import de.bund.bva.isyfact.security.core.TenantJwtIssuerValidator;
 import de.bund.bva.isyfact.security.oauth2.client.Authentifizierungsmanager;
 import de.bund.bva.isyfact.security.xmlparser.RolePrivilegesMapper;
 
@@ -76,4 +94,46 @@ public class IsySecurityAutoConfiguration {
         return new IsyOAuth2Security(rolePrivilegesMapper, berechtigungsmanager, authentifizierungsmanager);
     }
 
+    /**
+     * Configuration for multi-tenancy support. This configuration is applied when the property
+     * "spring.security.oauth2.resourceserver.jwt.issuer-uri" is either set to "false" or not specified
+     * in the application properties, and tenant-specific configurations are provided in the application properties.
+     */
+    @Configuration
+    @ConditionalOnProperty(name = "spring.security.oauth2.resourceserver.jwt.issuer-uri", havingValue = "false", matchIfMissing = true)
+    @Conditional(TenantsNotEmptyCondition.class)
+    public static class MultiTenancyConfiguredDependentBeans {
+
+        @Bean
+        @ConfigurationProperties(prefix = "isy.security.oauth2.resourceserver.jwt")
+        public JWTConfigurationProperties jwtConfigurationProperties() {
+            return new JWTConfigurationProperties();
+        }
+
+        @Bean
+        public TenantJwsKeySelector tenantJwsKeySelector(JWTConfigurationProperties jwtConfigurationProperties) {
+            return new TenantJwsKeySelector(jwtConfigurationProperties);
+        }
+
+        @Bean
+        public TenantJwtIssuerValidator tenantJwtIssuerValidator(JWTConfigurationProperties jwtConfigurationProperties) {
+            return new TenantJwtIssuerValidator(jwtConfigurationProperties);
+        }
+
+        @Bean
+        JWTProcessor<SecurityContext> jwtProcessor(TenantJwsKeySelector keySelector) {
+            ConfigurableJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
+            jwtProcessor.setJWTClaimsSetAwareJWSKeySelector(keySelector);
+            return jwtProcessor;
+        }
+
+        @Bean
+        JwtDecoder jwtDecoder(JWTProcessor<SecurityContext> jwtProcessor, OAuth2TokenValidator<Jwt> jwtValidator) {
+            NimbusJwtDecoder decoder = new NimbusJwtDecoder(jwtProcessor);
+            OAuth2TokenValidator<Jwt> validator =
+                    new DelegatingOAuth2TokenValidator<>(JwtValidators.createDefault(), jwtValidator);
+            decoder.setJwtValidator(validator);
+            return decoder;
+        }
+    }
 }

--- a/src/main/java/de/bund/bva/isyfact/security/condition/TenantsNotEmptyCondition.java
+++ b/src/main/java/de/bund/bva/isyfact/security/condition/TenantsNotEmptyCondition.java
@@ -1,0 +1,47 @@
+package de.bund.bva.isyfact.security.condition;
+
+import java.util.regex.Pattern;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.lang.NonNull;
+
+public class TenantsNotEmptyCondition implements Condition {
+
+    /**
+     * Pattern to match tenant issuer URI properties.
+     */
+    private static final Pattern TENANT_ISSUER_URI_PATTERN = Pattern.compile("isy\\.security\\.oauth2\\.resourceserver\\.jwt\\.tenants\\..+\\.issuer-uri");
+
+    @Override
+    public boolean matches(ConditionContext context, @NonNull AnnotatedTypeMetadata metadata) {
+        ConfigurableEnvironment env = (ConfigurableEnvironment) context.getEnvironment();
+        for (PropertySource<?> propertySource : env.getPropertySources()) {
+            if (propertySource instanceof EnumerablePropertySource) {
+                if (isTenantIssuerUriPresent((EnumerablePropertySource<?>) propertySource)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the tenant issuer URI is present in the given property source.
+     *
+     * @param propertySource the property source to check
+     * @return true if the tenant issuer URI is present, false otherwise
+     */
+    private boolean isTenantIssuerUriPresent(EnumerablePropertySource<?> propertySource) {
+        for (String propertyName : propertySource.getPropertyNames()) {
+            if (TENANT_ISSUER_URI_PATTERN.matcher(propertyName).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/de/bund/bva/isyfact/security/config/JWTConfigurationProperties.java
+++ b/src/main/java/de/bund/bva/isyfact/security/config/JWTConfigurationProperties.java
@@ -1,0 +1,46 @@
+package de.bund.bva.isyfact.security.config;
+
+import java.util.Map;
+
+import org.springframework.validation.annotation.Validated;
+
+
+public class JWTConfigurationProperties {
+
+    /** The tenants. */
+    private Map<String, JwtServerProperties> tenants;
+
+    public Map<String, JwtServerProperties> getTenants() {
+        return tenants;
+    }
+
+    public void setTenants(Map<String, JwtServerProperties> tenants) {
+        this.tenants = tenants;
+    }
+
+    @Validated
+    public static class JwtServerProperties {
+
+        /** The issuer URI. */
+        private String issuerUri;
+
+        /** The JWK set URI. */
+        private String jwkSetUri;
+
+        public String getIssuerUri() {
+            return issuerUri;
+        }
+
+        public void setIssuerUri(String issuerUri) {
+            this.issuerUri = issuerUri;
+        }
+
+        public String getJwkSetUri() {
+            return jwkSetUri;
+        }
+
+        public void setJwkSetUri(String jwkSetUri) {
+            this.jwkSetUri = jwkSetUri;
+        }
+    }
+}

--- a/src/main/java/de/bund/bva/isyfact/security/core/TenantJwsKeySelector.java
+++ b/src/main/java/de/bund/bva/isyfact/security/core/TenantJwsKeySelector.java
@@ -1,0 +1,82 @@
+package de.bund.bva.isyfact.security.core;
+
+import java.net.URL;
+import java.security.Key;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.KeySourceException;
+import com.nimbusds.jose.proc.JWSAlgorithmFamilyJWSKeySelector;
+import com.nimbusds.jose.proc.JWSKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.JWTClaimsSetAwareJWSKeySelector;
+
+import de.bund.bva.isyfact.security.config.JWTConfigurationProperties;
+
+public class TenantJwsKeySelector implements JWTClaimsSetAwareJWSKeySelector<SecurityContext> {
+
+    /**
+     * The key selectors.
+     */
+    private final Map<String, JWSKeySelector<SecurityContext>> selectors = new ConcurrentHashMap<>();
+
+    /**
+     * The JWT properties.
+     */
+    private final JWTConfigurationProperties jwtProperties;
+
+    public TenantJwsKeySelector(JWTConfigurationProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
+    }
+
+    /**
+     * Select the JWS keys for a JWT.
+     *
+     * @param jwsHeader       the JWS header
+     * @param jwtClaimsSet    the JWT claims set
+     * @param securityContext the security context
+     * @return the JWS keys
+     * @throws KeySourceException if the keys cannot be selected
+     */
+    @Override
+    public List<? extends Key> selectKeys(JWSHeader jwsHeader, JWTClaimsSet jwtClaimsSet, SecurityContext securityContext)
+            throws KeySourceException {
+        return this.selectors.computeIfAbsent(toIssuer(jwtClaimsSet), this::fromIssuer)
+                .selectJWSKeys(jwsHeader, securityContext);
+    }
+
+    private String toIssuer(JWTClaimsSet claimSet) {
+        return claimSet.getIssuer();
+    }
+
+    /**
+     * Create a JWSKeySelector for a tenant.
+     *
+     * @param issuer the tenant
+     * @return the JWSKeySelector
+     */
+    private JWSKeySelector<SecurityContext> fromIssuer(String issuer) {
+        return jwtProperties.getTenants().values().stream()
+                .filter(tenant -> tenant.getIssuerUri().equals(issuer))
+                .findAny()
+                .map(tenant -> fromUri(tenant.getJwkSetUri()))
+                .orElseThrow(() -> new IllegalArgumentException("unknown tenant: " + issuer));
+    }
+
+    /**
+     * Create a JWSKeySelector from a JWKSet URI.
+     *
+     * @param uri the JWKSet URI
+     * @return the JWSKeySelector
+     */
+    private JWSKeySelector<SecurityContext> fromUri(String uri) {
+        try {
+            return JWSAlgorithmFamilyJWSKeySelector.fromJWKSetURL(new URL(uri));
+        } catch (Exception ex) {
+            throw new IllegalArgumentException(ex);
+        }
+    }
+}

--- a/src/main/java/de/bund/bva/isyfact/security/core/TenantJwtIssuerValidator.java
+++ b/src/main/java/de/bund/bva/isyfact/security/core/TenantJwtIssuerValidator.java
@@ -1,0 +1,66 @@
+package de.bund.bva.isyfact.security.core;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtIssuerValidator;
+import org.springframework.stereotype.Component;
+
+import de.bund.bva.isyfact.security.config.JWTConfigurationProperties;
+
+@Component
+public class TenantJwtIssuerValidator implements OAuth2TokenValidator<Jwt> {
+
+    /** The JWT properties. */
+    private final JWTConfigurationProperties jwtProperties;
+
+    /** The validators. */
+    private final Map<String, JwtIssuerValidator> validators = new ConcurrentHashMap<>();
+
+    public TenantJwtIssuerValidator(JWTConfigurationProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
+    }
+
+    /**
+     * Validate the JWT.
+     *
+     * @param token
+     *         the token to validate
+     * @return the validation result
+     */
+    @Override
+    public OAuth2TokenValidatorResult validate(Jwt token) {
+        return validators.computeIfAbsent(toIssuer(token), this::fromIssuer)
+                .validate(token);
+    }
+
+    /**
+     * Get the issuer from a JWT.
+     *
+     * @param jwt
+     *         the JWT
+     * @return the tenant
+     */
+    private String toIssuer(Jwt jwt) {
+        return jwt.getIssuer().toString();
+    }
+
+    /**
+     * Create a JwtIssuerValidator for an issuer.
+     *
+     * @param issuer
+     *         the tenant
+     * @return the JwtIssuerValidator
+     */
+    private JwtIssuerValidator fromIssuer(String issuer) {
+        return jwtProperties.getTenants().values().stream()
+                .filter(tenant -> tenant.getIssuerUri().equals(issuer))
+                .findAny()
+                .map(JWTConfigurationProperties.JwtServerProperties::getIssuerUri)
+                .map(JwtIssuerValidator::new)
+                .orElseThrow(() -> new IllegalArgumentException("unknown tenant: " + issuer));
+    }
+}

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/Authentifizierungsmanager.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/Authentifizierungsmanager.java
@@ -1,8 +1,11 @@
 package de.bund.bva.isyfact.security.oauth2.client;
 
+import java.time.Duration;
+
 import org.springframework.lang.Nullable;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
 
 import de.bund.bva.isyfact.security.config.IsyOAuth2ClientConfigurationProperties;
 
@@ -34,6 +37,31 @@ public interface Authentifizierungsmanager {
      *         if authentication fails
      */
     void authentifiziere(String oauth2ClientRegistrationId) throws AuthenticationException;
+
+    /**
+     * Performs authentication for the given {@code oauth2ClientRegistrationId} as described in
+     * {@link Authentifizierungsmanager#authentifiziere(String)} if the SecurityContext does not contain
+     * an Authentication of type {@link AbstractOAuth2TokenAuthenticationToken} or the token received from the
+     * SecurityContext is considered as expired with regard to the {@code expirationTimeOffset}.
+     * The {@code expirationTimeOffset} provides a time frame before token expiry during which the token is considered as already expired.
+     * <p>
+     * For clients configured to use the Client Credentials Flow (grant type: client_credentials), authentication will only reliably
+     * occur for an {@code expirationTimeOffset} less than 60 seconds, because Spring will by default skip authentication in the
+     * {@link org.springframework.security.oauth2.client.ClientCredentialsOAuth2AuthorizedClientProvider ClientCredentialsOAuth2AuthorizedClientProvider}
+     * if the access token provided by the corresponding {@link org.springframework.security.oauth2.client.OAuth2AuthorizedClient OAuth2AuthorizedClient}
+     * does not expire within 60 seconds from current time.
+     * When using this method for re-authentication with the Client Credentials Flow, this means that a time longer
+     * than 60 seconds before the next call of this method could lead to token expiration.
+     *
+     * @param oauth2ClientRegistrationId
+     *         registration ID of the OAuth 2.0 Client to authorize
+     * @param expirationTimeOffset
+     *         the time frame before expiry during which the token is considered as already expired
+     * @throws AuthenticationException
+     *         if authentication fails
+     * @see Authentifizierungsmanager#authentifiziere(String)
+     */
+    void authentifiziere(String oauth2ClientRegistrationId, Duration expirationTimeOffset) throws AuthenticationException;
 
     /**
      * Attempts to create and authorize a client with the given credentials via the OAuth 2.0 Client Credentials Flow.

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
@@ -1,5 +1,7 @@
 package de.bund.bva.isyfact.security.oauth2.client;
 
+import java.time.Duration;
+
 import org.springframework.lang.Nullable;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -18,6 +20,7 @@ import de.bund.bva.isyfact.security.config.IsyOAuth2ClientConfigurationPropertie
 import de.bund.bva.isyfact.security.oauth2.client.authentication.token.ClientCredentialsClientRegistrationAuthenticationToken;
 import de.bund.bva.isyfact.security.oauth2.client.authentication.token.ClientCredentialsRegistrationIdAuthenticationToken;
 import de.bund.bva.isyfact.security.oauth2.client.authentication.token.PasswordClientRegistrationAuthenticationToken;
+import de.bund.bva.isyfact.security.oauth2.util.IsySecurityTokenUtil;
 
 /**
  * Default implementation of the {@link Authentifizierungsmanager} that should suffice for most use cases.
@@ -64,6 +67,13 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
     public void authentifiziere(String oauth2ClientRegistrationId) throws AuthenticationException {
         Authentication unauthenticatedToken = getAuthenticationTokenForRegistrationId(oauth2ClientRegistrationId);
         authenticateAndChangeAuthenticatedPrincipal(unauthenticatedToken);
+    }
+
+    @Override
+    public void authentifiziere(String oauth2ClientRegistrationId, Duration expirationTimeOffset) throws AuthenticationException {
+        if (!IsySecurityTokenUtil.hasOAuth2Token() || IsySecurityTokenUtil.hasTokenExpired(expirationTimeOffset)) {
+            authentifiziere(oauth2ClientRegistrationId);
+        }
     }
 
     @Override

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenClaimNames.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenClaimNames.java
@@ -1,0 +1,54 @@
+package de.bund.bva.isyfact.security.oauth2.util;
+
+import java.util.ResourceBundle;
+
+/**
+ * Contains aliases for the claims commonly expected in IsyFact applications that might not necessarily be
+ * standard claim names of an OAuth 2.0 / OpenID Connect token.
+ * If possible consider accessing these only with the matching methods in {@link IsySecurityTokenUtil}.
+ * <p>
+ * All the aliased values can be changed in case your environment uses different claim names by
+ * creating a file {@code config/isy-security-token.properties} and assigning the claims as follows:
+ * <pre>
+ * isy.security.oauth2.claim.login = preferred_username
+ * isy.security.oauth2.claim.userId = internekennung
+ * isy.security.oauth2.claim.bhknz = bhknz
+ * isy.security.oauth2.claim.displayName = name
+ * </pre>
+ *
+ * @see IsySecurityTokenUtil
+ */
+public final class IsySecurityTokenClaimNames {
+
+    /** The resource bundle that contains the token configuration. */
+    private static final ResourceBundle BUNDLE = ResourceBundle.getBundle("config.isy-security-token");
+
+    /** The prefix for all configuration properties. */
+    private static final String PREFIX = "isy.security.oauth2.claim.";
+
+    /** The JWT claim name that contains the login. */
+    public static final String LOGIN = getConfigPropertyValueAsString("login");
+
+    /** The JWT claim name that contains the user id. */
+    public static final String USER_ID = getConfigPropertyValueAsString("userId");
+
+    /** The JWT claim name that contains the BHKNZ (Behoerdenkennzeichen). */
+    public static final String BHKNZ = getConfigPropertyValueAsString("bhknz");
+
+    /** The JWT claim name that contains the display name. */
+    public static final String DISPLAY_NAME = getConfigPropertyValueAsString("displayName");
+
+    private IsySecurityTokenClaimNames() {
+    }
+
+    /**
+     * Returns the value of the configuration property with the given suffix.
+     *
+     * @param suffix
+     *         the suffix of the configuration property
+     * @return the String value of the configuration property
+     */
+    private static String getConfigPropertyValueAsString(String suffix) {
+        return BUNDLE.getString(PREFIX + suffix);
+    }
+}

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtil.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtil.java
@@ -3,7 +3,6 @@ package de.bund.bva.isyfact.security.oauth2.util;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
-import java.util.ResourceBundle;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -14,49 +13,11 @@ import org.springframework.security.oauth2.server.resource.BearerTokenErrors;
 import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
 
 /**
- * This class contains utility methods for isy-security. It provides access to the claims of the current OAuth 2.0 token.
+ * This class contains utility methods for working with tokens in isy-security.
+ * It provides easy access to the claims defined in {@link IsySecurityTokenClaimNames}
+ * and all claims of the current OAuth 2.0 token.
  */
 public final class IsySecurityTokenUtil {
-
-    /**
-     * The resource bundle that contains the token configuration.
-     */
-    private static final ResourceBundle BUNDLE = ResourceBundle.getBundle("config.isy-security-token");
-
-    /**
-     * The JWT claim name that contains the login.
-     */
-    public static final String LOGIN = getConfigPropertyValueAsString("login");
-
-    /**
-     * The JWT claim name that contains the userId.
-     */
-    public static final String USER_ID = getConfigPropertyValueAsString("userId");
-
-    /**
-     * The JWT claim name that contains the bhknz (Behoerdenkennzeichen).
-     */
-    public static final String BHKNZ = getConfigPropertyValueAsString("bhknz");
-
-    /**
-     * The JWT claim name that contains the display name.
-     */
-    public static final String DISPLAY_NAME = getConfigPropertyValueAsString("displayName");
-
-    /**
-     * The prefix for all configuration properties.
-     */
-    private static final String PREFIX = "isy.security.oauth2.claim.";
-
-    /**
-     * Returns the value of the configuration property with the given suffix.
-     *
-     * @param suffix the suffix of the configuration property
-     * @return the String value of the configuration property
-     */
-    private static String getConfigPropertyValueAsString(String suffix) {
-        return BUNDLE.getString(PREFIX + suffix);
-    }
 
     /**
      * Utility class should not be instantiated.
@@ -70,7 +31,7 @@ public final class IsySecurityTokenUtil {
      * @return the login of the current user
      */
     public static Optional<String> getLogin() {
-        String login = (String) getTokenAttribute(LOGIN);
+        String login = (String) getTokenAttribute(IsySecurityTokenClaimNames.LOGIN);
         return Optional.ofNullable(login);
     }
 
@@ -80,7 +41,7 @@ public final class IsySecurityTokenUtil {
      * @return the userId of the current user or the Subject identifier (sub) if the userId is not set
      */
     public static String getUserId() {
-        String userId = (String) getTokenAttribute(USER_ID);
+        String userId = (String) getTokenAttribute(IsySecurityTokenClaimNames.USER_ID);
         if (userId == null) {
             return (String) getTokenAttribute(StandardClaimNames.SUB);
         } else {
@@ -94,7 +55,7 @@ public final class IsySecurityTokenUtil {
      * @return the bhknz of the current user
      */
     public static Optional<String> getBhknz() {
-        String bhknz = (String) getTokenAttribute(BHKNZ);
+        String bhknz = (String) getTokenAttribute(IsySecurityTokenClaimNames.BHKNZ);
         return Optional.ofNullable(bhknz);
     }
 
@@ -104,7 +65,7 @@ public final class IsySecurityTokenUtil {
      * @return the display name of the current user or the login if the display name is not set
      */
     public static Optional<String> getDisplayName() {
-        String displayName = (String) getTokenAttribute(DISPLAY_NAME);
+        String displayName = (String) getTokenAttribute(IsySecurityTokenClaimNames.DISPLAY_NAME);
         if (displayName == null) {
             return getLogin();
         }
@@ -131,7 +92,7 @@ public final class IsySecurityTokenUtil {
      * @param expirationTimeOffset
      *         the time frame before expiry during which the token is considered as already expired
      * @return {@code true} if the token has expired or the expiresAt property of the token is not set,
-     *         else {@code false}
+     * else {@code false}
      * @throws OAuth2AuthenticationException
      *         if the authenticated principal is not a {@link AbstractOAuth2TokenAuthenticationToken}
      */
@@ -161,11 +122,10 @@ public final class IsySecurityTokenUtil {
      * Checks if the {@link SecurityContextHolder} holds an {@link AbstractOAuth2TokenAuthenticationToken} object.
      *
      * @return {@code true} if the current authentication in the SecurityContext is an instance of
-     *         {@link AbstractOAuth2TokenAuthenticationToken}, else {@code false}
+     * {@link AbstractOAuth2TokenAuthenticationToken}, else {@code false}
      */
     public static boolean hasOAuth2Token() {
         Authentication currentAuthentication = SecurityContextHolder.getContext().getAuthentication();
         return currentAuthentication instanceof AbstractOAuth2TokenAuthenticationToken;
     }
-
 }

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtil.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtil.java
@@ -26,21 +26,22 @@ public final class IsySecurityTokenUtil {
     /**
      * The JWT claim name that contains the login.
      */
-    private static final String LOGIN = getConfigPropertyValueAsString("login");
+    public static final String LOGIN = getConfigPropertyValueAsString("login");
 
     /**
      * The JWT claim name that contains the userId.
      */
-    private static final String USERID = getConfigPropertyValueAsString("userId");
+    public static final String USER_ID = getConfigPropertyValueAsString("userId");
 
     /**
      * The JWT claim name that contains the bhknz (Behoerdenkennzeichen).
      */
-    private static final String BHKNZ = getConfigPropertyValueAsString("bhknz");
+    public static final String BHKNZ = getConfigPropertyValueAsString("bhknz");
+
     /**
      * The JWT claim name that contains the display name.
      */
-    private static final String DISPLAYNAME = getConfigPropertyValueAsString("displayName");
+    public static final String DISPLAY_NAME = getConfigPropertyValueAsString("displayName");
 
     /**
      * The prefix for all configuration properties.
@@ -79,7 +80,7 @@ public final class IsySecurityTokenUtil {
      * @return the userId of the current user or the Subject identifier (sub) if the userId is not set
      */
     public static String getUserId() {
-        String userId = (String) getTokenAttribute(USERID);
+        String userId = (String) getTokenAttribute(USER_ID);
         if (userId == null) {
             return (String) getTokenAttribute(StandardClaimNames.SUB);
         } else {
@@ -103,7 +104,7 @@ public final class IsySecurityTokenUtil {
      * @return the display name of the current user or the login if the display name is not set
      */
     public static Optional<String> getDisplayName() {
-        String displayName = (String) getTokenAttribute(DISPLAYNAME);
+        String displayName = (String) getTokenAttribute(DISPLAY_NAME);
         if (displayName == null) {
             return getLogin();
         }

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtil.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtil.java
@@ -1,11 +1,14 @@
 package de.bund.bva.isyfact.security.oauth2.util;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.ResourceBundle;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Token;
 import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
 import org.springframework.security.oauth2.server.resource.BearerTokenErrors;
 import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
@@ -112,12 +115,53 @@ public class IsySecurityTokenUtil {
      *         if the authenticated principal is not a {@link AbstractOAuth2TokenAuthenticationToken}
      */
     public static Object getTokenAttribute(String key) {
-        Authentication currentAuthentication = SecurityContextHolder.getContext().getAuthentication();
-        if (currentAuthentication instanceof AbstractOAuth2TokenAuthenticationToken) {
-            return ((AbstractOAuth2TokenAuthenticationToken<?>) currentAuthentication).getTokenAttributes().get(key);
+        return getAuthenticationToken().getTokenAttributes().get(key);
+    }
+
+    /**
+     * Checks if the {@link OAuth2Token} from the current SecurityContext has expired
+     * with a time offset of {@code expirationTimeOffset}.
+     *
+     * @param expirationTimeOffset
+     *         the time frame before expiry during which the token is considered as already expired
+     * @return {@code true} if the token has expired or the expiresAt property of the token is not set,
+     *         else {@code false}
+     * @throws OAuth2AuthenticationException
+     *         if the authenticated principal is not a {@link AbstractOAuth2TokenAuthenticationToken}
+     */
+    public static boolean hasTokenExpired(Duration expirationTimeOffset) {
+        OAuth2Token token = getAuthenticationToken().getToken();
+        if (token.getExpiresAt() != null) {
+            return Instant.now().isAfter(token.getExpiresAt().minus(expirationTimeOffset));
+        }
+        return true;
+    }
+
+    /**
+     * Retrieves the oauth2 authentication token from the SecurityContext if the currently authenticated principal
+     * is an OAuth 2.0 token.
+     *
+     * @return the {@link AbstractOAuth2TokenAuthenticationToken} from the SecurityContext
+     * @throws OAuth2AuthenticationException
+     *         if the authenticated principal is not a {@link AbstractOAuth2TokenAuthenticationToken}
+     */
+    public static AbstractOAuth2TokenAuthenticationToken<?> getAuthenticationToken() {
+        if (hasOAuth2Token()) {
+            return ((AbstractOAuth2TokenAuthenticationToken<?>) SecurityContextHolder.getContext().getAuthentication());
         } else {
             throw new OAuth2AuthenticationException(BearerTokenErrors.invalidToken("Authentication is not an OAuth2 token authentication."));
         }
+    }
+
+    /**
+     * Checks if the {@link SecurityContextHolder} holds an {@link AbstractOAuth2TokenAuthenticationToken} object.
+     *
+     * @return {@code true} if the current authentication in the SecurityContext is an instance of
+     *         {@link AbstractOAuth2TokenAuthenticationToken}, else {@code false}
+     */
+    public static boolean hasOAuth2Token() {
+        Authentication currentAuthentication = SecurityContextHolder.getContext().getAuthentication();
+        return currentAuthentication instanceof AbstractOAuth2TokenAuthenticationToken;
     }
 
 }

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtil.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtil.java
@@ -16,8 +16,7 @@ import org.springframework.security.oauth2.server.resource.authentication.Abstra
 /**
  * This class contains utility methods for isy-security. It provides access to the claims of the current OAuth 2.0 token.
  */
-public class IsySecurityTokenUtil {
-
+public final class IsySecurityTokenUtil {
 
     /**
      * The resource bundle that contains the token configuration.
@@ -56,6 +55,12 @@ public class IsySecurityTokenUtil {
      */
     private static String getConfigPropertyValueAsString(String suffix) {
         return BUNDLE.getString(PREFIX + suffix);
+    }
+
+    /**
+     * Utility class should not be instantiated.
+     */
+    private IsySecurityTokenUtil() {
     }
 
     /**
@@ -130,11 +135,9 @@ public class IsySecurityTokenUtil {
      *         if the authenticated principal is not a {@link AbstractOAuth2TokenAuthenticationToken}
      */
     public static boolean hasTokenExpired(Duration expirationTimeOffset) {
-        OAuth2Token token = getAuthenticationToken().getToken();
-        if (token.getExpiresAt() != null) {
-            return Instant.now().isAfter(token.getExpiresAt().minus(expirationTimeOffset));
-        }
-        return true;
+        return Optional.ofNullable(getAuthenticationToken().getToken().getExpiresAt())
+                .map(expiresAt -> Instant.now().isAfter(expiresAt.minus(expirationTimeOffset)))
+                .orElse(true);
     }
 
     /**

--- a/src/test/java/de/bund/bva/isyfact/security/AbstractOidcProviderTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/AbstractOidcProviderTest.java
@@ -23,7 +23,7 @@ public abstract class AbstractOidcProviderTest {
      * Authentication and authorization via EmbeddedOidcProviderMock based on WireMock.
      */
     @RegisterExtension
-    public static final EmbeddedOidcProviderMock embeddedOidcProvider = new EmbeddedOidcProviderMock(HOST, PORT, ISSUER_PATH);
+    public static final EmbeddedOidcProviderMock embeddedOidcProvider = new EmbeddedOidcProviderMock(HOST, PORT, ISSUER_PATH, 300);
 
     protected static void registerTestClients() {
         // client with authorization-grant-type=password

--- a/src/test/java/de/bund/bva/isyfact/security/IsySecurityTestConfiguration.java
+++ b/src/test/java/de/bund/bva/isyfact/security/IsySecurityTestConfiguration.java
@@ -2,6 +2,7 @@ package de.bund.bva.isyfact.security;
 
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
 /**
  * Test configuration for isy-security. Only scans for auto configurations.
@@ -11,6 +12,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
  */
 @SpringBootConfiguration
 @EnableAutoConfiguration
+@EnableMethodSecurity(securedEnabled = true)
 public class IsySecurityTestConfiguration {
 
 }

--- a/src/test/java/de/bund/bva/isyfact/security/authentication/AuthorityPrefixTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/authentication/AuthorityPrefixTest.java
@@ -13,10 +13,10 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import de.bund.bva.isyfact.security.IsySecurityTestConfiguration;
 
-@SpringBootTest(classes = { IsySecurityTestConfiguration.class, AuthorityPrefixTest.AnnotationTest.class })
+@SpringBootTest(classes = {IsySecurityTestConfiguration.class, AuthorityPrefixTest.AnnotationTest.class})
 public class AuthorityPrefixTest {
 
-    private static final String[] TEST_AUTHORITIES = { "PRIV_test", "ROLE_test" };
+    private static final String[] TEST_AUTHORITIES = {"PRIV_test"};
 
     @Autowired
     private AnnotationTest annotationTest;

--- a/src/test/java/de/bund/bva/isyfact/security/authentication/ClaimsOnlyOAuth2TokenTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/authentication/ClaimsOnlyOAuth2TokenTest.java
@@ -1,0 +1,125 @@
+package de.bund.bva.isyfact.security.authentication;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.SUB;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
+
+import de.bund.bva.isyfact.security.oauth2.util.IsySecurityTokenUtil;
+
+public class ClaimsOnlyOAuth2TokenTest {
+
+    @Test
+    public void subjectPutInProperClaim() {
+        String sub = "test_subject";
+        ClaimsOnlyOAuth2Token token = ClaimsOnlyOAuth2Token.withSubject(sub).build();
+
+        assertEquals(sub, token.getSubject());
+        assertEquals(claims(entry(SUB, sub)), token.getClaims());
+    }
+
+    @Test
+    public void loginPutInProperClaim() {
+        String sub = "test_subject";
+        String login = "test_login";
+        ClaimsOnlyOAuth2Token token = ClaimsOnlyOAuth2Token.withSubject(sub).login(login).build();
+
+        assertEquals(sub, token.getSubject());
+        assertEquals(claims(entry(SUB, sub), entry(IsySecurityTokenUtil.LOGIN, login)), token.getClaims());
+    }
+
+    @Test
+    public void bhknzPutInProperClaim() {
+        String sub = "test_subject";
+        String bhknz = "900600";
+        ClaimsOnlyOAuth2Token token = ClaimsOnlyOAuth2Token.withSubject(sub).bhknz(bhknz).build();
+
+        assertEquals(sub, token.getSubject());
+        assertEquals(claims(entry(SUB, sub), entry(IsySecurityTokenUtil.BHKNZ, bhknz)), token.getClaims());
+    }
+
+    @Test
+    public void userIdPutInProperClaim() {
+        String sub = "test_subject";
+        String userId = "test_user_id";
+        ClaimsOnlyOAuth2Token token = ClaimsOnlyOAuth2Token.withSubject(sub).userId(userId).build();
+
+        assertEquals(sub, token.getSubject());
+        assertEquals(claims(entry(SUB, sub), entry(IsySecurityTokenUtil.USER_ID, userId)), token.getClaims());
+    }
+
+    @Test
+    public void displayNamePutInProperClaim() {
+        String sub = "test_subject";
+        String displayName = "Martha Mustermann";
+        ClaimsOnlyOAuth2Token token = ClaimsOnlyOAuth2Token.withSubject(sub).displayName(displayName).build();
+
+        assertEquals(sub, token.getSubject());
+        assertEquals(claims(entry(SUB, sub), entry(IsySecurityTokenUtil.DISPLAY_NAME, displayName)), token.getClaims());
+    }
+
+    @Test
+    public void presetClaimCanBeOverwrittenWithNull() {
+        String sub = "test_subject";
+        ClaimsOnlyOAuth2Token token = ClaimsOnlyOAuth2Token.withSubject(sub)
+                .login(null).userId(null).bhknz(null).displayName(null)
+                .build();
+
+        assertEquals(claims(
+                entry(SUB, sub), entry(IsySecurityTokenUtil.LOGIN, null), entry(IsySecurityTokenUtil.USER_ID, null),
+                entry(IsySecurityTokenUtil.BHKNZ, null), entry(IsySecurityTokenUtil.DISPLAY_NAME, null)
+        ), token.getClaims());
+    }
+
+    @Test
+    public void setsNamedClaims() {
+        String sub = "test_subject";
+        String claimName = "my_custom_claim";
+        String claimValue = "test_value_for_custom_claim";
+        ClaimsOnlyOAuth2Token token = ClaimsOnlyOAuth2Token.withSubject(sub).claim(claimName, claimValue).build();
+
+        assertEquals(sub, token.getSubject());
+        assertEquals(claims(entry(SUB, sub), entry(claimName, claimValue)), token.getClaims());
+    }
+
+    @Test
+    public void getTokenValueThrowsException() {
+        assertThrows(RuntimeException.class,
+                () -> ClaimsOnlyOAuth2Token.withSubject("test_subject").build().getTokenValue());
+    }
+
+    @Test
+    public void asAuthenticationCreatesProperObject() {
+        String sub = "test_subject";
+        ClaimsOnlyOAuth2Token token = ClaimsOnlyOAuth2Token.withSubject(sub)
+                .displayName("Martha Mustermann")
+                .build();
+
+        AbstractOAuth2TokenAuthenticationToken<?> authentication = token.asAuthentication();
+
+        assertFalse(authentication.isAuthenticated());
+        assertEquals(sub, authentication.getName());
+        assertEquals(sub, authentication.getPrincipal());
+        assertEquals(token, authentication.getCredentials());
+        assertEquals(token, authentication.getToken());
+        assertEquals(token.getClaims(), authentication.getTokenAttributes());
+    }
+
+    @SafeVarargs
+    private static Map<String, String> claims(Map.Entry<String, String>... entries) {
+        Map<String, String> map = new HashMap<>();
+        map.put(IsySecurityTokenUtil.LOGIN, "");
+        map.put(IsySecurityTokenUtil.USER_ID, "");
+        map.put(IsySecurityTokenUtil.BHKNZ, "");
+        map.put(IsySecurityTokenUtil.DISPLAY_NAME, "");
+        for (Map.Entry<String, String> entry : entries) {
+            map.put(entry.getKey(), entry.getValue());
+        }
+        return map;
+    }
+}

--- a/src/test/java/de/bund/bva/isyfact/security/authentication/ClaimsOnlyOAuth2TokenTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/authentication/ClaimsOnlyOAuth2TokenTest.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
 
-import de.bund.bva.isyfact.security.oauth2.util.IsySecurityTokenUtil;
+import de.bund.bva.isyfact.security.oauth2.util.IsySecurityTokenClaimNames;
 
 public class ClaimsOnlyOAuth2TokenTest {
 
@@ -30,7 +30,7 @@ public class ClaimsOnlyOAuth2TokenTest {
         ClaimsOnlyOAuth2Token token = ClaimsOnlyOAuth2Token.withSubject(sub).login(login).build();
 
         assertEquals(sub, token.getSubject());
-        assertEquals(claims(entry(SUB, sub), entry(IsySecurityTokenUtil.LOGIN, login)), token.getClaims());
+        assertEquals(claims(entry(SUB, sub), entry(IsySecurityTokenClaimNames.LOGIN, login)), token.getClaims());
     }
 
     @Test
@@ -40,7 +40,7 @@ public class ClaimsOnlyOAuth2TokenTest {
         ClaimsOnlyOAuth2Token token = ClaimsOnlyOAuth2Token.withSubject(sub).bhknz(bhknz).build();
 
         assertEquals(sub, token.getSubject());
-        assertEquals(claims(entry(SUB, sub), entry(IsySecurityTokenUtil.BHKNZ, bhknz)), token.getClaims());
+        assertEquals(claims(entry(SUB, sub), entry(IsySecurityTokenClaimNames.BHKNZ, bhknz)), token.getClaims());
     }
 
     @Test
@@ -50,7 +50,7 @@ public class ClaimsOnlyOAuth2TokenTest {
         ClaimsOnlyOAuth2Token token = ClaimsOnlyOAuth2Token.withSubject(sub).userId(userId).build();
 
         assertEquals(sub, token.getSubject());
-        assertEquals(claims(entry(SUB, sub), entry(IsySecurityTokenUtil.USER_ID, userId)), token.getClaims());
+        assertEquals(claims(entry(SUB, sub), entry(IsySecurityTokenClaimNames.USER_ID, userId)), token.getClaims());
     }
 
     @Test
@@ -60,7 +60,7 @@ public class ClaimsOnlyOAuth2TokenTest {
         ClaimsOnlyOAuth2Token token = ClaimsOnlyOAuth2Token.withSubject(sub).displayName(displayName).build();
 
         assertEquals(sub, token.getSubject());
-        assertEquals(claims(entry(SUB, sub), entry(IsySecurityTokenUtil.DISPLAY_NAME, displayName)), token.getClaims());
+        assertEquals(claims(entry(SUB, sub), entry(IsySecurityTokenClaimNames.DISPLAY_NAME, displayName)), token.getClaims());
     }
 
     @Test
@@ -71,8 +71,8 @@ public class ClaimsOnlyOAuth2TokenTest {
                 .build();
 
         assertEquals(claims(
-                entry(SUB, sub), entry(IsySecurityTokenUtil.LOGIN, null), entry(IsySecurityTokenUtil.USER_ID, null),
-                entry(IsySecurityTokenUtil.BHKNZ, null), entry(IsySecurityTokenUtil.DISPLAY_NAME, null)
+                entry(SUB, sub), entry(IsySecurityTokenClaimNames.LOGIN, null), entry(IsySecurityTokenClaimNames.USER_ID, null),
+                entry(IsySecurityTokenClaimNames.BHKNZ, null), entry(IsySecurityTokenClaimNames.DISPLAY_NAME, null)
         ), token.getClaims());
     }
 
@@ -113,10 +113,10 @@ public class ClaimsOnlyOAuth2TokenTest {
     @SafeVarargs
     private static Map<String, String> claims(Map.Entry<String, String>... entries) {
         Map<String, String> map = new HashMap<>();
-        map.put(IsySecurityTokenUtil.LOGIN, "");
-        map.put(IsySecurityTokenUtil.USER_ID, "");
-        map.put(IsySecurityTokenUtil.BHKNZ, "");
-        map.put(IsySecurityTokenUtil.DISPLAY_NAME, "");
+        map.put(IsySecurityTokenClaimNames.LOGIN, "");
+        map.put(IsySecurityTokenClaimNames.USER_ID, "");
+        map.put(IsySecurityTokenClaimNames.BHKNZ, "");
+        map.put(IsySecurityTokenClaimNames.DISPLAY_NAME, "");
         for (Map.Entry<String, String> entry : entries) {
             map.put(entry.getKey(), entry.getValue());
         }

--- a/src/test/java/de/bund/bva/isyfact/security/authentication/ResourceServerMultiTenancyTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/authentication/ResourceServerMultiTenancyTest.java
@@ -43,6 +43,10 @@ public class ResourceServerMultiTenancyTest {
 
     /**
      * Authentication and authorization via EmbeddedOidcProviderMock based on WireMock.
+     * A ping using a token from embeddedOidcProvider1 and embeddedOidcProvider2 is possible (tested in shouldAllowPingFromTestrealm1() and shouldAllowPingFromTestrealm2()),
+     *     as both tenants are defined in application-multi-tenancy.yaml.
+     * A ping with a token from embeddedOidcProvider3 fails as unauthorized (tested in shouldDenyPingFromTestrealm3())
+     *     since no matching tenant is defined in application-multi-tenancy.yaml.
      */
     @RegisterExtension
     public static final EmbeddedOidcProviderMock embeddedOidcProvider1 = new EmbeddedOidcProviderMock(HOST, PORT1, ISSUER_PATH1);

--- a/src/test/java/de/bund/bva/isyfact/security/authentication/ResourceServerMultiTenancyTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/authentication/ResourceServerMultiTenancyTest.java
@@ -1,0 +1,121 @@
+package de.bund.bva.isyfact.security.authentication;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import de.bund.bva.isyfact.security.IsySecurityTestConfiguration;
+import de.bund.bva.isyfact.security.example.config.SecurityConfig;
+import de.bund.bva.isyfact.security.example.rest.ExampleRestController;
+import de.bund.bva.isyfact.security.test.oidcprovider.EmbeddedOidcProviderMock;
+
+@ActiveProfiles("multi-tenancy")
+@SpringBootTest(classes = {
+        IsySecurityTestConfiguration.class, SecurityConfig.class, ExampleRestController.class
+}, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@EnableAutoConfiguration
+public class ResourceServerMultiTenancyTest {
+
+    protected static final String ISSUER_PATH1 = "/auth/realms/testrealm1";
+    protected static final String ISSUER_PATH2 = "/auth/realms/testrealm2";
+    protected static final String ISSUER_PATH3 = "/auth/realms/testrealm3";
+
+    private static final String HOST = "localhost";
+
+    private static final int PORT1 = 9095;
+    private static final int PORT2 = 9096;
+    private static final int PORT3 = 9097;
+
+    /**
+     * Authentication and authorization via EmbeddedOidcProviderMock based on WireMock.
+     */
+    @RegisterExtension
+    public static final EmbeddedOidcProviderMock embeddedOidcProvider1 = new EmbeddedOidcProviderMock(HOST, PORT1, ISSUER_PATH1);
+    @RegisterExtension
+    public static final EmbeddedOidcProviderMock embeddedOidcProvider2 = new EmbeddedOidcProviderMock(HOST, PORT2, ISSUER_PATH2);
+    @RegisterExtension
+    public static final EmbeddedOidcProviderMock embeddedOidcProvider3 = new EmbeddedOidcProviderMock(HOST, PORT3, ISSUER_PATH3);
+    @LocalServerPort
+    private int port;
+
+    private String pingUri;
+
+    @BeforeEach
+    public void setup() {
+        embeddedOidcProvider1.removeAllClients();
+        embeddedOidcProvider2.removeAllClients();
+        embeddedOidcProvider3.removeAllClients();
+        pingUri = "http://localhost:" + port + "/ping";
+    }
+
+    /**
+     * Test with an issuer that is configured as a tenant in the resource server configuration.
+     */
+    @Test
+    public void shouldAllowPingFromTestrealm1() {
+        // manually get a token signed by the OIDC provider
+        String token = embeddedOidcProvider1.getAccessTokenString("cc-client", "testuser", Optional.empty(),
+                Collections.singleton("Rolle_A"));
+
+        String body = WebClient.create().get().uri(pingUri)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .exchangeToMono(response -> {
+                    assertEquals(HttpStatus.OK, response.statusCode());
+                    return response.bodyToMono(String.class);
+                }).block();
+
+        assertEquals("true", body);
+
+    }
+
+    /**
+     * Test with an issuer that is configured as a tenant in the resource server configuration.
+     */
+    @Test
+    public void shouldAllowPingFromTestrealm2() {
+        // manually get a token signed by the OIDC provider
+        String token = embeddedOidcProvider2.getAccessTokenString("cc-client", "testuser", Optional.empty(),
+                Collections.singleton("Rolle_A"));
+
+        String body = WebClient.create().get().uri(pingUri)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .exchangeToMono(response -> {
+                    assertEquals(HttpStatus.OK, response.statusCode());
+                    return response.bodyToMono(String.class);
+                }).block();
+
+        assertEquals("true", body);
+        verify(0, getRequestedFor(urlMatching(ISSUER_PATH2 + ".*")));
+    }
+
+    @Test
+    public void shouldDenyPingFromTestrealm3() {
+        // manually get a token signed by the OIDC provider
+        String token = embeddedOidcProvider3.getAccessTokenString("cc-client", "testuser", Optional.empty(),
+                Collections.singleton("Rolle_A"));
+
+        WebClient.create().get().uri(pingUri)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .exchangeToMono(response -> {
+                    // status 401 Unauthorized expected as the tenant was not set
+                    assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode());
+                    return response.bodyToMono(String.class);
+                }).block();
+    }
+
+}

--- a/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerTest.java
@@ -9,16 +9,23 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -143,6 +150,48 @@ public class AuthentifizierungsmanagerTest extends AbstractOidcProviderTest {
         assertEquals("123456", value.getBhknz());
 
         assertEquals(mockJwt, SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    public void testAuthRefreshesIfTokenIsNotOAuth2() {
+        Authentication notOAuth2Authentication = new TestingAuthenticationToken("principal", "credentials");
+        SecurityContextHolder.getContext().setAuthentication(notOAuth2Authentication);
+
+        authentifizierungsmanager.authentifiziere("cc-client", Duration.ofSeconds(60));
+
+        // refreshed because existing authentication got replaced with the mockJwt
+        assertEquals(mockJwt, SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    public void testAuthRefreshesIfTokenIsExpired() {
+        Instant expiresAt = Instant.now().plus(1, ChronoUnit.MINUTES);
+        Jwt token = Mockito.mock(Jwt.class);
+        when(token.getExpiresAt()).thenReturn(expiresAt);
+
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(token));
+
+        authentifizierungsmanager.authentifiziere("cc-client", Duration.ofSeconds(60));
+
+        // refreshed because existing authentication got replaced with the mockJwt
+        assertEquals(mockJwt, SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    public void testAuthDoesNotRefreshIfTokenIsOAuth2AndNotExpired() {
+        Duration tokenExpiryDelta = Duration.ofSeconds(60);
+
+        Instant expiresAt = Instant.now().plus(tokenExpiryDelta).plusSeconds(1);
+        Jwt token = Mockito.mock(Jwt.class);
+        when(token.getExpiresAt()).thenReturn(expiresAt);
+        JwtAuthenticationToken authentication = new JwtAuthenticationToken(token);
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        authentifizierungsmanager.authentifiziere("cc-client", tokenExpiryDelta);
+
+        // not refreshed because authentication stays the same
+        assertEquals(authentication, SecurityContextHolder.getContext().getAuthentication());
     }
 
     @Test

--- a/src/test/java/de/bund/bva/isyfact/security/oauth2/client/annotation/MethodAuthenticationTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/oauth2/client/annotation/MethodAuthenticationTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.doAnswer;
         properties = {"test.auth.client-id = my-auth-client"}
 )
 @EnableAutoConfiguration
+@EnableMethodSecurity(securedEnabled = true)
 public class MethodAuthenticationTest {
 
     private static final String[] TEST_AUTHORITIES = {"PRIV_test", "ROLE_test"};

--- a/src/test/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtilTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtilTest.java
@@ -1,83 +1,124 @@
 package de.bund.bva.isyfact.security.oauth2.util;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import de.bund.bva.isyfact.security.authentication.ClaimsOnlyOAuth2AuthenticationToken;
+import de.bund.bva.isyfact.security.authentication.ClaimsOnlyOAuth2Token;
 
 public class IsySecurityTokenUtilTest {
 
+    public static final String TEST_SUB = "test_sub";
+    public static final String TEST_USER_ID = "test_userId";
+    public static final String TEST_LOGIN = "test_login";
+    public static final String TEST_BHKNZ = "test_bhknz";
+    public static final String TEST_DISPLAY_NAME = "test_displayname";
 
     @BeforeEach
     public void setUp() {
         SecurityContextHolder.clearContext(); // Sicherstellen, dass der Kontext vor jedem Test zurückgesetzt wird
     }
 
-    @Test
-    public void testGetUserId() {
-        Map<String, Object> attributes = new HashMap<>();
-        attributes.put(StandardClaimNames.SUB, "test_sub");
-        attributes.put("internekennung", "test_userId");
-        mockSecurityContextWithTokenAttributes(attributes);
-
-        assertEquals("test_userId", IsySecurityTokenUtil.getUserId());
+    public static Stream<Authentication> getUserId() {
+        return Stream.of(
+                buildJwtAuthenticationToken(builder -> builder.claim("internekennung", TEST_USER_ID)),
+                buildClaimsOnlyOAuth2AuthenticationToken(builder -> builder.userId(TEST_USER_ID))
+        );
     }
 
-    @Test
-    public void testGetUserIdWhenNull() {
-        Map<String, Object> attributes = new HashMap<>();
-        attributes.put("internekennung", null);
-        attributes.put(StandardClaimNames.SUB, "test_sub");
-        mockSecurityContextWithTokenAttributes(attributes);
+    @ParameterizedTest
+    @MethodSource
+    public void getUserId(Authentication authentication) {
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        assertEquals("test_sub", IsySecurityTokenUtil.getUserId());
+        assertEquals(TEST_USER_ID, IsySecurityTokenUtil.getUserId());
     }
 
+    public static Stream<Authentication> getUserIdWhenNull() {
+        return Stream.of(
+                buildJwtAuthenticationToken(builder -> builder.claim("internekennung", null)),
+                buildBearerTokenAuthentication(builder -> builder.claim("internekennung", null)),
+                buildClaimsOnlyOAuth2AuthenticationToken(builder -> builder.userId(null))
+        );
+    }
 
-    @Test
-    public void testGetUserIdWhenEmpty() {
-        Map<String, Object> attributes = new HashMap<>();
-        attributes.put("internekennung", "");
-        mockSecurityContextWithTokenAttributes(attributes);
+    @ParameterizedTest
+    @MethodSource
+    public void getUserIdWhenNull(Authentication authentication) {
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        assertEquals(TEST_SUB, IsySecurityTokenUtil.getUserId());
+    }
+
+    public static Stream<Authentication> getUserIdWhenEmpty() {
+        return Stream.of(
+                buildJwtAuthenticationToken(builder -> builder.claim("internekennung", "")),
+                buildBearerTokenAuthentication(builder -> builder.claim("internekennung", "")),
+                buildClaimsOnlyOAuth2AuthenticationToken(builder -> builder.userId(""))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void getUserIdWhenEmpty(Authentication authentication) {
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         assertEquals("", IsySecurityTokenUtil.getUserId());
     }
 
-    @Test
-    public void testGetLogin() {
-        Map<String, Object> attributes = new HashMap<>();
-        attributes.put("preferred_username", "test_login");
-        mockSecurityContextWithTokenAttributes(attributes);
-
-        assertTrue(IsySecurityTokenUtil.getLogin().isPresent());
-        assertEquals("test_login", IsySecurityTokenUtil.getLogin().get());
+    public static Stream<Authentication> getLogin() {
+        return Stream.of(
+                buildJwtAuthenticationToken(builder -> builder.claim("preferred_username", TEST_LOGIN)),
+                buildBearerTokenAuthentication(builder -> builder.claim("preferred_username", TEST_LOGIN)),
+                buildClaimsOnlyOAuth2AuthenticationToken(builder -> builder.login(TEST_LOGIN))
+        );
     }
 
-    @Test
-    public void testGetLoginWhenEmpty() {
-        Map<String, Object> attributes = new HashMap<>();
-        attributes.put("preferred_username", "");
-        mockSecurityContextWithTokenAttributes(attributes);
+    @ParameterizedTest
+    @MethodSource
+    public void getLogin(Authentication authentication) {
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        assertTrue(IsySecurityTokenUtil.getLogin().isPresent());
+        assertEquals(TEST_LOGIN, IsySecurityTokenUtil.getLogin().get());
+    }
+
+    public static Stream<Authentication> getLoginWhenEmpty() {
+        return Stream.of(
+                buildJwtAuthenticationToken(builder -> builder.claim("preferred_username", "")),
+                buildBearerTokenAuthentication(builder -> builder.claim("preferred_username", "")),
+                buildClaimsOnlyOAuth2AuthenticationToken(builder -> builder.login(""))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void getLoginWhenEmpty(Authentication authentication) {
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         Optional<String> optLogin = IsySecurityTokenUtil.getLogin();
 
@@ -85,32 +126,53 @@ public class IsySecurityTokenUtilTest {
         assertEquals("", optLogin.get());
     }
 
-    @Test
-    public void testGetLoginWhenNull() {
-        Map<String, Object> attributes = new HashMap<>();
-        attributes.put("preferred_username", null);
-        mockSecurityContextWithTokenAttributes(attributes);
+    public static Stream<Authentication> getLoginWhenNull() {
+        return Stream.of(
+                buildJwtAuthenticationToken(builder -> builder.claim("preferred_username", null)),
+                buildBearerTokenAuthentication(builder -> builder.claim("preferred_username", null)),
+                buildClaimsOnlyOAuth2AuthenticationToken(builder -> builder.login(null))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void getLoginWhenNull(Authentication authentication) {
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         assertFalse(IsySecurityTokenUtil.getLogin().isPresent());
     }
 
-    @Test
-    public void testGetBhknz() {
-        Map<String, Object> attributes = new HashMap<>();
-        attributes.put("bhknz", "test_bhknz");
-        mockSecurityContextWithTokenAttributes(attributes);
+    public static Stream<Authentication> getBhknz() {
+        return Stream.of(
+                buildJwtAuthenticationToken(builder -> builder.claim("bhknz", TEST_BHKNZ)),
+                buildBearerTokenAuthentication(builder -> builder.claim("bhknz", TEST_BHKNZ)),
+                buildClaimsOnlyOAuth2AuthenticationToken(builder -> builder.bhknz(TEST_BHKNZ))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void getBhknz(Authentication authentication) {
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         Optional<String> optBhknz = IsySecurityTokenUtil.getBhknz();
 
         assertTrue(optBhknz.isPresent());
-        assertEquals("test_bhknz", optBhknz.get());
+        assertEquals(TEST_BHKNZ, optBhknz.get());
     }
 
-    @Test
-    public void testGetBhknzWhenEmpty() {
-        Map<String, Object> attributes = new HashMap<>();
-        attributes.put("bhknz", "");
-        mockSecurityContextWithTokenAttributes(attributes);
+    private static Stream<Authentication> getBhknzWhenEmpty() {
+        return Stream.of(
+                buildJwtAuthenticationToken(builder -> builder.claim("bhknz", "")),
+                buildBearerTokenAuthentication(builder -> builder.claim("bhknz", "")),
+                buildClaimsOnlyOAuth2AuthenticationToken(builder -> builder.bhknz(""))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void getBhknzWhenEmpty(Authentication authentication) {
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         Optional<String> optBhknz = IsySecurityTokenUtil.getBhknz();
 
@@ -118,32 +180,53 @@ public class IsySecurityTokenUtilTest {
         assertEquals("", optBhknz.get());
     }
 
-    @Test
-    public void testGetBhknzWhenNull() {
-        Map<String, Object> attributes = new HashMap<>();
-        attributes.put("bhknz", null);
-        mockSecurityContextWithTokenAttributes(attributes);
+    private static Stream<Authentication> getBhknzWhenNull() {
+        return Stream.of(
+                buildJwtAuthenticationToken(builder -> builder.claim("bhknz", null)),
+                buildBearerTokenAuthentication(builder -> builder.claim("bhknz", null)),
+                buildClaimsOnlyOAuth2AuthenticationToken(builder -> builder.bhknz(null))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void getBhknzWhenNull(Authentication authentication) {
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         assertFalse(IsySecurityTokenUtil.getBhknz().isPresent());
     }
 
-    @Test
-    public void testGetDisplayName() {
-        Map<String, Object> attributes = new HashMap<>();
-        attributes.put("name", "test_displayname");
-        mockSecurityContextWithTokenAttributes(attributes);
+    public static Stream<Authentication> getDisplayName() {
+        return Stream.of(
+                buildJwtAuthenticationToken(builder -> builder.claim("name", TEST_DISPLAY_NAME)),
+                buildBearerTokenAuthentication(builder -> builder.claim("name", TEST_DISPLAY_NAME)),
+                buildClaimsOnlyOAuth2AuthenticationToken(builder -> builder.displayName(TEST_DISPLAY_NAME))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void getDisplayName(Authentication authentication) {
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         Optional<String> optDisplayName = IsySecurityTokenUtil.getDisplayName();
 
         assertTrue(optDisplayName.isPresent());
-        assertEquals("test_displayname", optDisplayName.get());
+        assertEquals(TEST_DISPLAY_NAME, optDisplayName.get());
     }
 
-    @Test
-    public void testGetDisplayNameEmpty() {
-        Map<String, Object> attributes = new HashMap<>();
-        attributes.put("name", "");
-        mockSecurityContextWithTokenAttributes(attributes);
+    public static Stream<Authentication> getDisplayNameEmpty() {
+        return Stream.of(
+                buildJwtAuthenticationToken(builder -> builder.claim("name", "")),
+                buildBearerTokenAuthentication(builder -> builder.claim("name", "")),
+                buildClaimsOnlyOAuth2AuthenticationToken(builder -> builder.displayName(""))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void getDisplayNameEmpty(Authentication authentication) {
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         Optional<String> optDisplayName = IsySecurityTokenUtil.getDisplayName();
 
@@ -151,54 +234,80 @@ public class IsySecurityTokenUtilTest {
         assertEquals("", optDisplayName.get());
     }
 
-    @Test
-    public void testGetDisplayNameNull() {
-        Map<String, Object> attributes = new HashMap<>();
-        attributes.put("name", null);
-        attributes.put("preferred_username", "test_login");
-        mockSecurityContextWithTokenAttributes(attributes);
+    public static Stream<Authentication> getDisplayNameNull() {
+        return Stream.of(
+                buildJwtAuthenticationToken(builder -> builder.claim("name", null).claim("preferred_username", TEST_LOGIN)),
+                buildBearerTokenAuthentication(builder -> builder.claim("name", null).claim("preferred_username", TEST_LOGIN)),
+                buildClaimsOnlyOAuth2AuthenticationToken(builder -> builder.displayName(null).login(TEST_LOGIN))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void getDisplayNameNull(Authentication authentication) {
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         Optional<String> optDisplayName = IsySecurityTokenUtil.getDisplayName();
 
         assertTrue(optDisplayName.isPresent());
-        assertEquals("test_login", optDisplayName.get());
+        assertEquals(TEST_LOGIN, optDisplayName.get());
     }
 
-    @Test
-    public void testHasTokenExpiredWhenTokenExpired() {
+    public static Stream<Authentication> hasTokenExpiredTrueWhenJwtBearerExpired() {
         Instant expiresAt = Instant.now().plus(1, ChronoUnit.MINUTES);
+        return Stream.of(
+                buildJwtAuthenticationToken(builder -> builder.expiresAt(expiresAt)),
+                buildBearerTokenAuthentication(builder -> builder.expiresAt(expiresAt))
+        );
+    }
 
-        Jwt token = Mockito.mock(Jwt.class);
-        when(token.getExpiresAt()).thenReturn(expiresAt);
-
-        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(token));
+    @ParameterizedTest
+    @MethodSource
+    public void hasTokenExpiredTrueWhenJwtBearerExpired(Authentication authentication) {
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         assertTrue(IsySecurityTokenUtil.hasTokenExpired(Duration.ofSeconds(61)));
-        verify(token).getExpiresAt();
     }
 
-    @Test
-    public void testHasTokenExpiredWhenTokenNotExpired() {
+    public static Stream<Authentication> hasTokenExpiredFalseWhenJwtBearerNotExpired() {
         Instant expiresAt = Instant.now().plus(1, ChronoUnit.DAYS);
+        return Stream.of(
+                buildJwtAuthenticationToken(builder -> builder.expiresAt(expiresAt)),
+                buildBearerTokenAuthentication(builder -> builder.expiresAt(expiresAt))
+        );
+    }
 
-        Jwt token = Mockito.mock(Jwt.class);
-        when(token.getExpiresAt()).thenReturn(expiresAt);
-
-        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(token));
+    @ParameterizedTest
+    @MethodSource
+    public void hasTokenExpiredFalseWhenJwtBearerNotExpired(Authentication authentication) {
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         assertFalse(IsySecurityTokenUtil.hasTokenExpired(Duration.ofSeconds(60)));
-        verify(token).getExpiresAt();
+    }
+
+    public static Stream<Authentication> hasTokenExpiredTrueWhenJwtBearerWithoutExpiredAtProperty() {
+        // set a non expired timestamp first and then remove the claim
+        Instant expiresAt = Instant.now().plus(1, ChronoUnit.DAYS);
+        return Stream.of(
+                buildJwtAuthenticationToken(builder -> builder.expiresAt(expiresAt).claims(claim -> claim.remove(JwtClaimNames.EXP))),
+                buildBearerTokenAuthentication(builder -> builder.expiresAt(expiresAt).claims(claims -> claims.remove(IdTokenClaimNames.EXP)))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void hasTokenExpiredTrueWhenJwtBearerWithoutExpiredAtProperty(Authentication authentication) {
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        assertTrue(IsySecurityTokenUtil.hasTokenExpired(Duration.ofSeconds(60)));
     }
 
     @Test
-    public void testHasTokenExpiredWhenTokenWithoutExpiredAtProperty() {
-        Jwt token = Mockito.mock(Jwt.class);
-        when(token.getExpiresAt()).thenReturn(null);
-
-        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(token));
+    public void hasTokenExpiredTrueWhenClaimOnlyTokenWithEXPCLaim() {
+        Instant expiresAt = Instant.now().plus(1, ChronoUnit.DAYS);
+        SecurityContextHolder.getContext().setAuthentication(buildClaimsOnlyOAuth2AuthenticationToken(builder -> builder.claim(JwtClaimNames.EXP, expiresAt)));
 
         assertTrue(IsySecurityTokenUtil.hasTokenExpired(Duration.ofSeconds(60)));
-        verify(token).getExpiresAt();
     }
 
     @Test
@@ -209,10 +318,40 @@ public class IsySecurityTokenUtilTest {
         assertThrows(OAuth2AuthenticationException.class, IsySecurityTokenUtil::getAuthenticationToken);
     }
 
-    private void mockSecurityContextWithTokenAttributes(Map<String, Object> attributes) {
-        Map<String, Object> attrMap = new HashMap<>(attributes);
-        AbstractOAuth2TokenAuthenticationToken<?> authenticationToken = Mockito.mock(AbstractOAuth2TokenAuthenticationToken.class);
-        when(authenticationToken.getTokenAttributes()).thenReturn(Collections.unmodifiableMap(attrMap));
-        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+    @Test
+    public void getAuthenticationTokenThrowsExceptionWhenTokenIsNull() {
+        SecurityContextHolder.getContext().setAuthentication(null);
+
+        assertThrows(OAuth2AuthenticationException.class, IsySecurityTokenUtil::getAuthenticationToken);
+    }
+
+    @Test
+    public void getAuthenticationTokenThrowsExceptionWhenSecurityContextIsEmpty() {
+        SecurityContextHolder.clearContext();
+
+        assertThrows(OAuth2AuthenticationException.class, IsySecurityTokenUtil::getAuthenticationToken);
+    }
+
+    private static JwtAuthenticationToken buildJwtAuthenticationToken(UnaryOperator<Jwt.Builder> builder) {
+        Jwt jwt = builder.apply(Jwt.withTokenValue("dummy")
+                        .header("dummy_header", "dummy_header_value")
+                        .claim(StandardClaimNames.SUB, TEST_SUB))
+                .build();
+        return new JwtAuthenticationToken(jwt);
+    }
+
+    private static BearerTokenAuthentication buildBearerTokenAuthentication(UnaryOperator<OidcIdToken.Builder> builder) {
+        OidcIdToken idToken = builder.apply(OidcIdToken.withTokenValue("dummy")
+                        .claim(StandardClaimNames.SUB, TEST_SUB))
+                .build();
+        DefaultOidcUser principal = new DefaultOidcUser(null, idToken);
+        return new BearerTokenAuthentication(principal, new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
+                principal.getIdToken().getTokenValue(), principal.getIssuedAt(), principal.getExpiresAt()),
+                principal.getAuthorities());
+    }
+
+    private static ClaimsOnlyOAuth2AuthenticationToken buildClaimsOnlyOAuth2AuthenticationToken(UnaryOperator<ClaimsOnlyOAuth2Token.Builder> builder) {
+        ClaimsOnlyOAuth2Token token = builder.apply(ClaimsOnlyOAuth2Token.withSubject(TEST_SUB)).build();
+        return token.asAuthentication();
     }
 }

--- a/src/test/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtilTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtilTest.java
@@ -1,8 +1,6 @@
 package de.bund.bva.isyfact.security.oauth2.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -18,7 +16,10 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
@@ -173,7 +174,7 @@ public class IsySecurityTokenUtilTest {
         SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(token));
 
         assertTrue(IsySecurityTokenUtil.hasTokenExpired(Duration.ofSeconds(61)));
-        verify(token, times(2)).getExpiresAt();
+        verify(token).getExpiresAt();
     }
 
     @Test
@@ -186,7 +187,7 @@ public class IsySecurityTokenUtilTest {
         SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(token));
 
         assertFalse(IsySecurityTokenUtil.hasTokenExpired(Duration.ofSeconds(60)));
-        verify(token, times(2)).getExpiresAt();
+        verify(token).getExpiresAt();
     }
 
     @Test
@@ -197,7 +198,15 @@ public class IsySecurityTokenUtilTest {
         SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(token));
 
         assertTrue(IsySecurityTokenUtil.hasTokenExpired(Duration.ofSeconds(60)));
-        verify(token, times(1)).getExpiresAt();
+        verify(token).getExpiresAt();
+    }
+
+    @Test
+    public void getAuthenticationTokenThrowsExceptionWhenTokenIsNotOAuth2() {
+        Authentication notOAuth2Authentication = new TestingAuthenticationToken("principal", "credentials");
+        SecurityContextHolder.getContext().setAuthentication(notOAuth2Authentication);
+
+        assertThrows(OAuth2AuthenticationException.class, IsySecurityTokenUtil::getAuthenticationToken);
     }
 
     private void mockSecurityContextWithTokenAttributes(Map<String, Object> attributes) {

--- a/src/test/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtilTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtilTest.java
@@ -40,7 +40,7 @@ public class IsySecurityTokenUtilTest {
 
     @BeforeEach
     public void setUp() {
-        SecurityContextHolder.clearContext(); // Sicherstellen, dass der Kontext vor jedem Test zurückgesetzt wird
+        SecurityContextHolder.clearContext(); // Ensure that the context is cleared before each test is executed.
     }
 
     public static Stream<Authentication> getUserId() {
@@ -286,7 +286,7 @@ public class IsySecurityTokenUtilTest {
     }
 
     public static Stream<Authentication> hasTokenExpiredTrueWhenJwtBearerWithoutExpiredAtProperty() {
-        // set a non expired timestamp first and then remove the claim
+        // Set a non expired timestamp first and then remove the claim.
         Instant expiresAt = Instant.now().plus(1, ChronoUnit.DAYS);
         return Stream.of(
                 buildJwtAuthenticationToken(builder -> builder.expiresAt(expiresAt).claims(claim -> claim.remove(JwtClaimNames.EXP))),

--- a/src/test/resources/application-multi-tenancy.yaml
+++ b/src/test/resources/application-multi-tenancy.yaml
@@ -1,0 +1,12 @@
+isy:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          tenants:
+            tenant1:
+              issuer-uri: http://localhost:9095/auth/realms/testrealm1
+              jwk-set-uri: http://localhost:9095/auth/realms/testrealm1/protocol/openid-connect/certs
+            tenant2:
+              issuer-uri: http://localhost:9096/auth/realms/testrealm2
+              jwk-set-uri: http://localhost:9096/auth/realms/testrealm2/protocol/openid-connect/certs


### PR DESCRIPTION
* feat: IFS-2804 remove @EnableMethodSecurity Annotation fom Autoconfiguration
* docs: IFS-2804 update CHANGELOG.md
* feat: IFS-3833 add custom JwsKeySelector, JwtIssuerValidator and JWTConfigurationProperties for multitenancy and a new Condition for tenants check
* feat: IFS-3833 adjust IsyAutoConfiguration for multitenancy support
* test: IFS-3833 extend tests for multitenancy support
* chore: IFS-3833 update changelogs
* docs: IFS-3833 add comment in multitenancy test
* feat: IFS-2248 add functionality to check token expiration and availability of AbstractOAuth2TokenAuthenticationToken in SecurityContext, refactor methods
* feat: IFS-2248 add functionality for (re-)authentication to IsyOAuth2Authentifizierungsmanager
* test: IFS-2248 add test cases for token expiration check in IsySecurityTokenUtil
* test: IFS-2248 fix token life-time in EmbeddedOidcProviderStub, adjust test classes accordingly in order to avoid failures
* chore: IFS-2248 update changelog
* chore: IFS-2248 improve test coverage
* feat(security): IFS-4248 add an OAuth2AuthenticationToken that contains only claims
* test(security): IFS-4248 rework IsySecurityTokenUtilTest to also test the new token
* refactor(security): IFS-4228 move claim names to separate class
* chore: IFS-4248 adjust comments
* chore: IFS-4248 update changelogs
* docs: IFS-4006 add admonition regarding changes to the CSRF filter
* chore: IFS-4577 changelog and release notes