### PR TITLE
[Sprint 128] IFS-4601 lizenzheader bereinigen

### DIFF
--- a/src/main/java/de/bund/bva/isyfact/security/authentication/RolePrivilegeGrantedAuthoritiesConverter.java
+++ b/src/main/java/de/bund/bva/isyfact/security/authentication/RolePrivilegeGrantedAuthoritiesConverter.java
@@ -1,6 +1,11 @@
 package de.bund.bva.isyfact.security.authentication;
 
-import de.bund.bva.isyfact.security.xmlparser.RolePrivilegesMapper;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.convert.converter.Converter;
@@ -10,11 +15,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Set;
+import de.bund.bva.isyfact.security.xmlparser.RolePrivilegesMapper;
 
 /**
  * Based on {@link org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter} but with additional

--- a/src/main/java/de/bund/bva/isyfact/security/core/IsyOAuth2Berechtigungsmanager.java
+++ b/src/main/java/de/bund/bva/isyfact/security/core/IsyOAuth2Berechtigungsmanager.java
@@ -1,6 +1,11 @@
 package de.bund.bva.isyfact.security.core;
 
-import de.bund.bva.isyfact.security.oauth2.util.IsySecurityTokenUtil;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.access.AccessDeniedException;
@@ -11,11 +16,7 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
 import org.springframework.util.Assert;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.Collectors;
+import de.bund.bva.isyfact.security.oauth2.util.IsySecurityTokenUtil;
 
 /**
  * Default implementation of the {@link Berechtigungsmanager} that should suffice for most use cases.

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/annotation/AuthenticateInterceptor.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/annotation/AuthenticateInterceptor.java
@@ -1,7 +1,8 @@
 package de.bund.bva.isyfact.security.oauth2.client.annotation;
 
-import de.bund.bva.isyfact.security.oauth2.client.Authentifizierungsmanager;
-import de.bund.bva.isyfact.util.logging.MdcHelper;
+import java.lang.reflect.Method;
+import java.util.UUID;
+
 import org.aopalliance.aop.Advice;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
@@ -16,8 +17,8 @@ import org.springframework.security.authorization.method.AuthorizationIntercepto
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.Assert;
 
-import java.lang.reflect.Method;
-import java.util.UUID;
+import de.bund.bva.isyfact.security.oauth2.client.Authentifizierungsmanager;
+import de.bund.bva.isyfact.util.logging.MdcHelper;
 
 /**
  * MethodInterceptor that authenticates an OAuth 2.0 client and sets the authenticated principal in the Security Context.

--- a/src/main/java/de/bund/bva/isyfact/security/xmlparser/RolePrivilegesMapper.java
+++ b/src/main/java/de/bund/bva/isyfact/security/xmlparser/RolePrivilegesMapper.java
@@ -1,10 +1,5 @@
 package de.bund.bva.isyfact.security.xmlparser;
 
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.core.io.Resource;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
@@ -14,6 +9,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.Resource;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 public class RolePrivilegesMapper {
 

--- a/src/main/java/de/bund/bva/isyfact/util/logging/LoggingKonstanten.java
+++ b/src/main/java/de/bund/bva/isyfact/util/logging/LoggingKonstanten.java
@@ -1,28 +1,5 @@
 package de.bund.bva.isyfact.util.logging;
 
-/*
- * #%L
- * isy-logging
- * %%
- *
- * %%
- * See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.
- * The Federal Office of Administration (Bundesverwaltungsamt, BVA)
- * licenses this file to you under the Apache License, Version 2.0 (the
- * License). You may not use this file except in compliance with the
- * License. You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied. See the License for the specific language governing
- * permissions and limitations under the License.
- * #L%
- */
-
 /**
  * Konstantenklasse zur Verwaltung gemeinsam genutzer Konstanten von isy-logging.
  */

--- a/src/main/java/de/bund/bva/isyfact/util/logging/MdcHelper.java
+++ b/src/main/java/de/bund/bva/isyfact/util/logging/MdcHelper.java
@@ -1,25 +1,4 @@
-package de.bund.bva.isyfact.util.logging;/*
- * #%L
- * isy-logging
- * %%
- *
- * %%
- * See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.
- * The Federal Office of Administration (Bundesverwaltungsamt, BVA)
- * licenses this file to you under the Apache License, Version 2.0 (the
- * License). You may not use this file except in compliance with the
- * License. You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied. See the License for the specific language governing
- * permissions and limitations under the License.
- * #L%
- */
+package de.bund.bva.isyfact.util.logging;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/test/java/de/bund/bva/isyfact/security/BerechtigungsmanagerTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/BerechtigungsmanagerTest.java
@@ -4,8 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/src/test/java/de/bund/bva/isyfact/security/authentication/ClaimsOnlyOAuth2TokenTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/authentication/ClaimsOnlyOAuth2TokenTest.java
@@ -1,7 +1,9 @@
 package de.bund.bva.isyfact.security.authentication;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.entry;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.SUB;
 
 import java.util.HashMap;

--- a/src/test/java/de/bund/bva/isyfact/security/authentication/RolePrivilegesMapperTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/authentication/RolePrivilegesMapperTest.java
@@ -1,6 +1,5 @@
 package de.bund.bva.isyfact.security.authentication;
 
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.tuple;

--- a/src/test/java/de/bund/bva/isyfact/security/authentication/TokenPropagationTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/authentication/TokenPropagationTest.java
@@ -2,9 +2,7 @@ package de.bund.bva.isyfact.security.authentication;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.Collections;
 

--- a/src/test/java/de/bund/bva/isyfact/security/example/service/ExampleMethodAuthentication.java
+++ b/src/test/java/de/bund/bva/isyfact/security/example/service/ExampleMethodAuthentication.java
@@ -1,10 +1,11 @@
 package de.bund.bva.isyfact.security.example.service;
 
-import de.bund.bva.isyfact.security.oauth2.client.annotation.Authenticate;
-import de.bund.bva.isyfact.util.logging.MdcHelper;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+
+import de.bund.bva.isyfact.security.oauth2.client.annotation.Authenticate;
+import de.bund.bva.isyfact.util.logging.MdcHelper;
 
 public class ExampleMethodAuthentication {
 

--- a/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerTest.java
@@ -4,10 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.time.Duration;
 import java.time.Instant;

--- a/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerWithoutClientsConfiguredTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerWithoutClientsConfiguredTest.java
@@ -4,10 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/de/bund/bva/isyfact/security/oauth2/client/annotation/MethodAuthenticationTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/oauth2/client/annotation/MethodAuthenticationTest.java
@@ -1,8 +1,15 @@
 package de.bund.bva.isyfact.security.oauth2.client.annotation;
 
-import de.bund.bva.isyfact.security.example.service.ExampleMethodAuthentication;
-import de.bund.bva.isyfact.security.oauth2.client.Authentifizierungsmanager;
-import de.bund.bva.isyfact.util.logging.MdcHelper;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.AdditionalMatchers.not;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,15 +22,9 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.AdditionalMatchers.not;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
+import de.bund.bva.isyfact.security.example.service.ExampleMethodAuthentication;
+import de.bund.bva.isyfact.security.oauth2.client.Authentifizierungsmanager;
+import de.bund.bva.isyfact.util.logging.MdcHelper;
 
 @SpringBootTest(
         classes = {AuthenticateInterceptor.class, ExampleMethodAuthentication.class},

--- a/src/test/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtilTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtilTest.java
@@ -1,6 +1,9 @@
 package de.bund.bva.isyfact.security.oauth2.util;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.time.Instant;

--- a/src/test/java/de/bund/bva/isyfact/security/test/RsaKeyGenerator.java
+++ b/src/test/java/de/bund/bva/isyfact/security/test/RsaKeyGenerator.java
@@ -1,11 +1,16 @@
 package de.bund.bva.isyfact.security.test;
 
-import de.bund.bva.isyfact.security.test.oidcprovider.EmbeddedOidcProviderStub;
-
-import java.security.*;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
+
+import de.bund.bva.isyfact.security.test.oidcprovider.EmbeddedOidcProviderStub;
 
 /**
  * Class to generate RSA key pairs. It is use by the {@link EmbeddedOidcProviderStub} to generate key pairs if they are not

--- a/src/test/java/de/bund/bva/isyfact/util/logging/MdcHelperTest.java
+++ b/src/test/java/de/bund/bva/isyfact/util/logging/MdcHelperTest.java
@@ -1,12 +1,12 @@
 package de.bund.bva.isyfact.util.logging;
 
-import org.junit.jupiter.api.Test;
-import org.slf4j.MDC;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
 
 /**
  * Testfälle des MDC-Helper.


### PR DESCRIPTION
* feat: IFS-4601 removes javadoc license information in each class
* refactor: IFS-4601 removes line breaks
* refactor: IFS-4601 optimizes imports