### PR TITLE
[Sprint 135] IFS-4812 Sicheres Hashing für Caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # 5.0.0
+
+### Breaking Change
+- `IFS-4812`: Verwendung sicherer Hashfunktion für Caching
+
 ### Features
 - `IFS-4577`: Portierung fehlender Tickets aus isyfact-standards
 - `IFS-4591`: Hinzufügen von Authentifizierungsmethoden zur Authentifizierung von Clients und Systemen ohne Issuer-URI.

--- a/docs/modules/ROOT/pages/nutzungsvorgaben.adoc
+++ b/docs/modules/ROOT/pages/nutzungsvorgaben.adoc
@@ -381,6 +381,8 @@ NOTE: `ClientCredentialsRegistrationIdAuthenticationToken` wird nicht gecacht, d
 |isy.security.cache.ttl |0 |Time-to-Live in Sekunden. `0` = Cache ist deaktiviert.
 |isy.security.cache.maxelements |10000 |Maximale Anzahl von gecachten Einträgen.
 |isy.security.cache.token-expiration-time-offset|60 |Minimale Restlebensdauer eines gecachten Tokens in Sekunden. Ist die Restlebensdauer kürzer als die Tokengültigkeit, wird ein neuer Token angefordert.
+|isy.security.cache.salt-bytes|64 |Anzahl der verwendeten Bytes für den Salt.
+|isy.security.cache.hash-algorithm|SHA-512 |Algorithmus für das Hashing der Tokens beim Generieren von Cache Keys.
 |===
 
 WARNING: Die Cache-TTL muss kürzer als die Token-Gültigkeitsdauer konfiguriert werden, um die Verwendung abgelaufener Authentifizierungen zu verhindern.

--- a/src/main/java/de/bund/bva/isyfact/security/config/IsySecurityConfigurationProperties.java
+++ b/src/main/java/de/bund/bva/isyfact/security/config/IsySecurityConfigurationProperties.java
@@ -63,6 +63,16 @@ public class IsySecurityConfigurationProperties {
          */
         private int tokenExpirationTimeOffset = 60;
 
+        /**
+         * Amount of bytes used for salt.
+         */
+        private int saltBytes = 64;
+
+        /**
+         * Algorithm used for hashing tokens.
+         */
+        private String hashAlgorithm = "SHA-512";
+
         public int getTtl() {
             return ttl;
         }
@@ -85,6 +95,22 @@ public class IsySecurityConfigurationProperties {
 
         public void setTokenExpirationTimeOffset(int tokenExpirationTimeOffset) {
             this.tokenExpirationTimeOffset = tokenExpirationTimeOffset;
+        }
+
+        public int getSaltBytes() {
+            return saltBytes;
+        }
+
+        public void setSaltBytes(int saltBytes) {
+            this.saltBytes = saltBytes;
+        }
+
+        public String getHashAlgorithm() {
+            return hashAlgorithm;
+        }
+
+        public void setHashAlgorithm(String hashAlgorithm) {
+            this.hashAlgorithm = hashAlgorithm;
         }
     }
 }

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
@@ -95,10 +95,8 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
     /** Salt to increase security of token hash. */
     private final byte[] salt;
 
-    /** The size of the salt byte array. */
-    private static final Integer SALT_BYTES = 64;
-
-    private static final String HASH_ALGORITHM = "SHA-512";
+    /** Algorithm used for hashing tokens. */
+    private final String hashAlgorithm;
 
     public IsyOAuth2Authentifizierungsmanager(ProviderManager providerManager,
                                               IsyOAuth2ClientConfigurationProperties isyOAuth2ClientProps,
@@ -113,7 +111,8 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
         this.authenticationCache = cacheSetupResult.cache;
         this.cacheEnabled = isySecurityConfigurationProps.getCache().getTtl() > 0;
         this.tokenExpirationTimeOffset = isySecurityConfigurationProps.getCache().getTokenExpirationTimeOffset();
-        this.salt = new byte[SALT_BYTES];
+        this.hashAlgorithm = isySecurityConfigurationProps.getCache().getHashAlgorithm();
+        this.salt = new byte[isySecurityConfigurationProps.getCache().getSaltBytes()];
         new SecureRandom().nextBytes(salt);
     }
 
@@ -366,14 +365,14 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
         // ClientCredentialsRegistrationIdAuthenticationToken will return null-value for cacheKey
         // and so it will not be cached by the logic of Isy-Security
         // because it is cached by Spring's OAuth2AuthorizedClientManager
-        byte[] cacheKey = isyAuthenticationToken.generateCacheKey(HASH_ALGORITHM, salt);
+        byte[] cacheKey = isyAuthenticationToken.generateCacheKey(hashAlgorithm, salt);
 
         if (cacheKey == null) {
             return performAuthentication(unauthenticatedToken);
         }
 
         String encodedCacheKey = Base64.getEncoder().encodeToString(
-            isyAuthenticationToken.generateCacheKey(HASH_ALGORITHM, salt)
+            isyAuthenticationToken.generateCacheKey(hashAlgorithm, salt)
         );
         Authentication cachedAuthentication = authenticationCache.get(encodedCacheKey);
         if (cachedAuthentication != null) {

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
@@ -90,6 +90,13 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
      */
     private final int tokenExpirationTimeOffset;
 
+
+    /** Salt to increase security of token hash. */
+    private final byte[] salt;
+
+    /** The size of the salt byte array. */
+    private static final Integer SALT_BYTES = 16;
+
     public IsyOAuth2Authentifizierungsmanager(ProviderManager providerManager,
                                               IsyOAuth2ClientConfigurationProperties isyOAuth2ClientProps,
                                               @Nullable ClientRegistrationRepository clientRegistrationRepository,
@@ -103,6 +110,8 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
         this.authenticationCache = cacheSetupResult.cache;
         this.cacheEnabled = isySecurityConfigurationProps.getCache().getTtl() > 0;
         this.tokenExpirationTimeOffset = isySecurityConfigurationProps.getCache().getTokenExpirationTimeOffset();
+        this.salt = new byte[SALT_BYTES];
+        new SecureRandom().nextBytes(salt);
     }
 
     @Override
@@ -354,7 +363,7 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
         // ClientCredentialsRegistrationIdAuthenticationToken will return null-value for cacheKey
         // and so it will not be cached by the logic of Isy-Security
         // because it is cached by Spring's OAuth2AuthorizedClientManager
-        byte[] cacheKey = isyAuthenticationToken.generateCacheKey();
+        byte[] cacheKey = isyAuthenticationToken.generateCacheKey(salt);
 
         if (cacheKey == null) {
             return performAuthentication(unauthenticatedToken);

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
@@ -92,12 +92,13 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
      */
     private final int tokenExpirationTimeOffset;
 
-
     /** Salt to increase security of token hash. */
     private final byte[] salt;
 
     /** The size of the salt byte array. */
-    private static final Integer SALT_BYTES = 16;
+    private static final Integer SALT_BYTES = 64;
+
+    private static final String HASH_ALGORITHM = "SHA-512";
 
     public IsyOAuth2Authentifizierungsmanager(ProviderManager providerManager,
                                               IsyOAuth2ClientConfigurationProperties isyOAuth2ClientProps,
@@ -365,13 +366,15 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
         // ClientCredentialsRegistrationIdAuthenticationToken will return null-value for cacheKey
         // and so it will not be cached by the logic of Isy-Security
         // because it is cached by Spring's OAuth2AuthorizedClientManager
-        byte[] cacheKey = isyAuthenticationToken.generateCacheKey(salt);
+        byte[] cacheKey = isyAuthenticationToken.generateCacheKey(HASH_ALGORITHM, salt);
 
         if (cacheKey == null) {
             return performAuthentication(unauthenticatedToken);
         }
 
-        String encodedCacheKey = Base64.getEncoder().encodeToString(isyAuthenticationToken.generateCacheKey(salt));
+        String encodedCacheKey = Base64.getEncoder().encodeToString(
+            isyAuthenticationToken.generateCacheKey(HASH_ALGORITHM, salt)
+        );
         Authentication cachedAuthentication = authenticationCache.get(encodedCacheKey);
         if (cachedAuthentication != null) {
             SecurityContextHolder.getContext().setAuthentication(cachedAuthentication);

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
@@ -1,6 +1,8 @@
 package de.bund.bva.isyfact.security.oauth2.client;
 
+import java.security.SecureRandom;
 import java.time.Duration;
+import java.util.Base64;
 
 import org.ehcache.Cache;
 import org.ehcache.CacheManager;
@@ -66,7 +68,7 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
      * Cache used to provide authentication data for repeated requests.
      * Can be configured via properties 'ttl' and 'maxelements'.
      */
-    private final Cache<byte[], Authentication> authenticationCache;
+    private final Cache<String, Authentication> authenticationCache;
 
     /** Returns whether the cache is enabled or not. */
     private final boolean cacheEnabled;
@@ -258,10 +260,10 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
             return new CacheSetupResult(null, null);
         }
 
-        CacheConfiguration<byte[], Authentication> cacheConfiguration =
+        CacheConfiguration<String, Authentication> cacheConfiguration =
             CacheConfigurationBuilder
                 .newCacheConfigurationBuilder(
-                    byte[].class,
+                    String.class,
                     Authentication.class,
                     ResourcePoolsBuilder.heap(properties.getCache().getMaxelements()))
                 .withExpiry(
@@ -274,7 +276,7 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
                 .withCache(CACHE_ALIAS, cacheConfiguration)
                 .build(true);
 
-        Cache<byte[], Authentication> cache = configuredCacheManager.getCache(CACHE_ALIAS, byte[].class, Authentication.class);
+        Cache<String, Authentication> cache = configuredCacheManager.getCache(CACHE_ALIAS, String.class, Authentication.class);
 
         return new CacheSetupResult(configuredCacheManager, cache);
     }
@@ -369,11 +371,12 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
             return performAuthentication(unauthenticatedToken);
         }
 
-        Authentication cachedAuthentication = authenticationCache.get(cacheKey);
+        String encodedCacheKey = Base64.getEncoder().encodeToString(isyAuthenticationToken.generateCacheKey(salt));
+        Authentication cachedAuthentication = authenticationCache.get(encodedCacheKey);
         if (cachedAuthentication != null) {
             SecurityContextHolder.getContext().setAuthentication(cachedAuthentication);
             if (IsySecurityTokenUtil.hasTokenExpired(Duration.ofSeconds(tokenExpirationTimeOffset))) {
-                authenticationCache.remove(cacheKey);
+                authenticationCache.remove(encodedCacheKey);
             } else {
                 return cachedAuthentication;
             }
@@ -381,7 +384,7 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
 
         Authentication authentication = performAuthentication(unauthenticatedToken);
         if (authentication != null && authentication.isAuthenticated()) {
-            authenticationCache.put(cacheKey, authentication);
+            authenticationCache.put(encodedCacheKey, authentication);
         }
 
         return authentication;
@@ -408,9 +411,9 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
         /**
          * The Cache.
          */
-        private final Cache<byte[], Authentication> cache;
+        private final Cache<String, Authentication> cache;
 
-        CacheSetupResult(CacheManager cacheManager, Cache<byte[], Authentication> cache) {
+        CacheSetupResult(CacheManager cacheManager, Cache<String, Authentication> cache) {
             this.cacheManager = cacheManager;
             this.cache = cache;
         }
@@ -419,7 +422,7 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
             return cacheManager;
         }
 
-        public Cache<byte[], Authentication> getCache() {
+        public Cache<String, Authentication> getCache() {
             return cache;
         }
     }

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
@@ -66,7 +66,7 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
      * Cache used to provide authentication data for repeated requests.
      * Can be configured via properties 'ttl' and 'maxelements'.
      */
-    private final Cache<Integer, Authentication> authenticationCache;
+    private final Cache<byte[], Authentication> authenticationCache;
 
     /** Returns whether the cache is enabled or not. */
     private final boolean cacheEnabled;
@@ -249,10 +249,10 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
             return new CacheSetupResult(null, null);
         }
 
-        CacheConfiguration<Integer, Authentication> cacheConfiguration =
+        CacheConfiguration<byte[], Authentication> cacheConfiguration =
             CacheConfigurationBuilder
                 .newCacheConfigurationBuilder(
-                    Integer.class,
+                    byte[].class,
                     Authentication.class,
                     ResourcePoolsBuilder.heap(properties.getCache().getMaxelements()))
                 .withExpiry(
@@ -265,7 +265,7 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
                 .withCache(CACHE_ALIAS, cacheConfiguration)
                 .build(true);
 
-        Cache<Integer, Authentication> cache = configuredCacheManager.getCache(CACHE_ALIAS, Integer.class, Authentication.class);
+        Cache<byte[], Authentication> cache = configuredCacheManager.getCache(CACHE_ALIAS, byte[].class, Authentication.class);
 
         return new CacheSetupResult(configuredCacheManager, cache);
     }
@@ -354,7 +354,7 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
         // ClientCredentialsRegistrationIdAuthenticationToken will return null-value for cacheKey
         // and so it will not be cached by the logic of Isy-Security
         // because it is cached by Spring's OAuth2AuthorizedClientManager
-        Integer cacheKey = isyAuthenticationToken.generateCacheKey();
+        byte[] cacheKey = isyAuthenticationToken.generateCacheKey();
 
         if (cacheKey == null) {
             return performAuthentication(unauthenticatedToken);
@@ -399,9 +399,9 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
         /**
          * The Cache.
          */
-        private final Cache<Integer, Authentication> cache;
+        private final Cache<byte[], Authentication> cache;
 
-        CacheSetupResult(CacheManager cacheManager, Cache<Integer, Authentication> cache) {
+        CacheSetupResult(CacheManager cacheManager, Cache<byte[], Authentication> cache) {
             this.cacheManager = cacheManager;
             this.cache = cache;
         }
@@ -410,7 +410,7 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
             return cacheManager;
         }
 
-        public Cache<Integer, Authentication> getCache() {
+        public Cache<byte[], Authentication> getCache() {
             return cache;
         }
     }

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractClientRegistrationAuthenticationToken.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractClientRegistrationAuthenticationToken.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.springframework.lang.Nullable;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.util.SerializationUtils;
 
 /**
  * Token that holds a {@link ClientRegistration}.
@@ -47,26 +48,21 @@ public abstract class AbstractClientRegistrationAuthenticationToken extends Abst
 
             ClientRegistration clientReg = getClientRegistration();
 
-            List<Object> objectsToHash = Arrays.asList(
-                getPrincipal(),
-                getBhknz(),
+            List<String> stringsToHash = Arrays.asList(
+                String.valueOf(getPrincipal()),
+                String.valueOf(getBhknz()),
                 clientReg.getProviderDetails().getIssuerUri(),
                 clientReg.getClientId(),
                 clientReg.getClientSecret(),
-                clientReg.getAuthorizationGrantType()
+                String.valueOf(clientReg.getAuthorizationGrantType())
             );
 
-            for (Object obj : objectsToHash) {
-                digest.update(getBytesSafely(obj));
-            }
+            byte[] serializedBytes = SerializationUtils.serialize(stringsToHash);
+            digest.update(serializedBytes);
 
             return digest.digest();
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(hashAlgorithm + " nicht verfügbar.", e);
         }
-    }
-
-    private byte[] getBytesSafely(Object obj) {
-        return obj != null ? obj.toString().getBytes() : new byte[0];
     }
 }

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractClientRegistrationAuthenticationToken.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractClientRegistrationAuthenticationToken.java
@@ -3,6 +3,8 @@ package de.bund.bva.isyfact.security.oauth2.client.authentication.token;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 import org.springframework.lang.Nullable;
@@ -51,23 +53,27 @@ public abstract class AbstractClientRegistrationAuthenticationToken extends Abst
             digest.update(salt);
 
             ClientRegistration clientReg = getClientRegistration();
-            String principal = getPrincipal().toString();
-            String bhknz = getBhknz() != null ? getBhknz() : "";
-            String issuerUri = clientReg.getProviderDetails().getIssuerUri();
-            String clientId = clientReg.getClientId();
-            String clientSecret = clientReg.getClientSecret();
-            String authorizationGrantType = clientReg.getAuthorizationGrantType().toString();
 
-            digest.update(principal.getBytes());
-            digest.update(bhknz.getBytes());
-            digest.update(issuerUri.getBytes());
-            digest.update(clientId.getBytes());
-            digest.update(clientSecret.getBytes());
-            digest.update(authorizationGrantType.getBytes());
+            List<Object> objectsToHash = Arrays.asList(
+                getPrincipal(),
+                getBhknz(),
+                clientReg.getProviderDetails().getIssuerUri(),
+                clientReg.getClientId(),
+                clientReg.getClientSecret(),
+                clientReg.getAuthorizationGrantType()
+            );
+
+            for (Object obj : objectsToHash) {
+                digest.update(getBytesSafely(obj));
+            }
 
             return digest.digest();
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("SHA-512 nicht verfügbar.", e);
         }
+    }
+
+    private byte[] getBytesSafely(Object obj) {
+        return obj != null ? obj.toString().getBytes() : new byte[0];
     }
 }

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractClientRegistrationAuthenticationToken.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractClientRegistrationAuthenticationToken.java
@@ -40,9 +40,9 @@ public abstract class AbstractClientRegistrationAuthenticationToken extends Abst
      * @return the generated cache key as hash code or null
      */
     @Override
-    public byte[] generateCacheKey(byte[] salt) {
+    public byte[] generateCacheKey(String hashAlgorithm, byte[] salt) {
         try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-512");
+            MessageDigest digest = MessageDigest.getInstance(hashAlgorithm);
             digest.update(salt);
 
             ClientRegistration clientReg = getClientRegistration();
@@ -62,7 +62,7 @@ public abstract class AbstractClientRegistrationAuthenticationToken extends Abst
 
             return digest.digest();
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("SHA-512 nicht verfügbar.", e);
+            throw new RuntimeException(hashAlgorithm + " nicht verfügbar.", e);
         }
     }
 

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractClientRegistrationAuthenticationToken.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractClientRegistrationAuthenticationToken.java
@@ -1,5 +1,8 @@
 package de.bund.bva.isyfact.security.oauth2.client.authentication.token;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.Objects;
 
 import org.springframework.lang.Nullable;
@@ -13,10 +16,15 @@ public abstract class AbstractClientRegistrationAuthenticationToken extends Abst
     /** Client Registration of the OAuth 2.0 client. */
     private final ClientRegistration clientRegistration;
 
+    /** Salt to ensure safe hash code */
+    private final byte[] salt;
+
     protected AbstractClientRegistrationAuthenticationToken(String principal, ClientRegistration clientRegistration, @Nullable String bhknz) {
         super(principal, bhknz);
         this.clientRegistration = clientRegistration;
         setAuthenticated(false);
+        salt = new byte[16];
+        new SecureRandom().nextBytes(salt);
     }
 
     public ClientRegistration getClientRegistration() {
@@ -37,14 +45,29 @@ public abstract class AbstractClientRegistrationAuthenticationToken extends Abst
      * @return the generated cache key as hash code or null
      */
     @Override
-    public Integer generateCacheKey() {
-        return Objects.hash(
-                getPrincipal(),
-                getBhknz(),
-                getClientRegistration().getProviderDetails().getIssuerUri(),
-                getClientRegistration().getClientId(),
-                getClientRegistration().getClientSecret(),
-                getClientRegistration().getAuthorizationGrantType()
-        );
+    public byte[] generateCacheKey() {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-512");
+            digest.update(salt);
+
+            ClientRegistration clientReg = getClientRegistration();
+            String principal = getPrincipal().toString();
+            String bhknz = getBhknz() != null ? getBhknz() : "";
+            String issuerUri = clientReg.getProviderDetails().getIssuerUri();
+            String clientId = clientReg.getClientId();
+            String clientSecret = clientReg.getClientSecret();
+            String authorizationGrantType = clientReg.getAuthorizationGrantType().toString();
+
+            digest.update(principal.getBytes());
+            digest.update(bhknz.getBytes());
+            digest.update(issuerUri.getBytes());
+            digest.update(clientId.getBytes());
+            digest.update(clientSecret.getBytes());
+            digest.update(authorizationGrantType.getBytes());
+
+            return digest.digest();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-512 nicht verfügbar.", e);
+        }
     }
 }

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractClientRegistrationAuthenticationToken.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractClientRegistrationAuthenticationToken.java
@@ -2,10 +2,8 @@ package de.bund.bva.isyfact.security.oauth2.client.authentication.token;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 import org.springframework.lang.Nullable;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
@@ -18,15 +16,10 @@ public abstract class AbstractClientRegistrationAuthenticationToken extends Abst
     /** Client Registration of the OAuth 2.0 client. */
     private final ClientRegistration clientRegistration;
 
-    /** Salt to ensure safe hash code */
-    private final byte[] salt;
-
     protected AbstractClientRegistrationAuthenticationToken(String principal, ClientRegistration clientRegistration, @Nullable String bhknz) {
         super(principal, bhknz);
         this.clientRegistration = clientRegistration;
         setAuthenticated(false);
-        salt = new byte[16];
-        new SecureRandom().nextBytes(salt);
     }
 
     public ClientRegistration getClientRegistration() {
@@ -47,7 +40,7 @@ public abstract class AbstractClientRegistrationAuthenticationToken extends Abst
      * @return the generated cache key as hash code or null
      */
     @Override
-    public byte[] generateCacheKey() {
+    public byte[] generateCacheKey(byte[] salt) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-512");
             digest.update(salt);

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractIsyAuthenticationToken.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractIsyAuthenticationToken.java
@@ -51,5 +51,5 @@ public abstract class AbstractIsyAuthenticationToken extends AbstractAuthenticat
     }
 
     @Nullable
-    public abstract Integer generateCacheKey();
+    public abstract byte[] generateCacheKey();
 }

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractIsyAuthenticationToken.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractIsyAuthenticationToken.java
@@ -51,5 +51,5 @@ public abstract class AbstractIsyAuthenticationToken extends AbstractAuthenticat
     }
 
     @Nullable
-    public abstract byte[] generateCacheKey();
+    public abstract byte[] generateCacheKey(byte[] salt);
 }

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractIsyAuthenticationToken.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractIsyAuthenticationToken.java
@@ -51,5 +51,5 @@ public abstract class AbstractIsyAuthenticationToken extends AbstractAuthenticat
     }
 
     @Nullable
-    public abstract byte[] generateCacheKey(byte[] salt);
+    public abstract byte[] generateCacheKey(String hashAlgorithm, byte[] salt);
 }

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/ClientCredentialsRegistrationIdAuthenticationToken.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/ClientCredentialsRegistrationIdAuthenticationToken.java
@@ -26,7 +26,7 @@ public class ClientCredentialsRegistrationIdAuthenticationToken extends Abstract
      * @return null
      */
     @Override
-    public Integer generateCacheKey() {
+    public byte[] generateCacheKey() {
         return null;
     }
 }

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/ClientCredentialsRegistrationIdAuthenticationToken.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/ClientCredentialsRegistrationIdAuthenticationToken.java
@@ -26,7 +26,7 @@ public class ClientCredentialsRegistrationIdAuthenticationToken extends Abstract
      * @return null
      */
     @Override
-    public byte[] generateCacheKey() {
+    public byte[] generateCacheKey(byte[] salt) {
         return null;
     }
 }

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/ClientCredentialsRegistrationIdAuthenticationToken.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/ClientCredentialsRegistrationIdAuthenticationToken.java
@@ -26,7 +26,7 @@ public class ClientCredentialsRegistrationIdAuthenticationToken extends Abstract
      * @return null
      */
     @Override
-    public byte[] generateCacheKey(byte[] salt) {
+    public byte[] generateCacheKey(String hashAlgorithm, byte[] salt) {
         return null;
     }
 }

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/PasswordClientRegistrationAuthenticationToken.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/PasswordClientRegistrationAuthenticationToken.java
@@ -49,11 +49,11 @@ public class PasswordClientRegistrationAuthenticationToken extends AbstractClien
      * @return the generated cache key as hash code or null
      */
     @Override
-    public byte[] generateCacheKey() {
+    public byte[] generateCacheKey(byte[] salt) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-512");
 
-            digest.update(super.generateCacheKey());
+            digest.update(super.generateCacheKey(salt));
             digest.update(getUsername().getBytes());
             digest.update(getPassword().getBytes());
 

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/PasswordClientRegistrationAuthenticationToken.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/PasswordClientRegistrationAuthenticationToken.java
@@ -1,5 +1,7 @@
 package de.bund.bva.isyfact.security.oauth2.client.authentication.token;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Objects;
 
 import org.springframework.lang.Nullable;
@@ -47,7 +49,17 @@ public class PasswordClientRegistrationAuthenticationToken extends AbstractClien
      * @return the generated cache key as hash code or null
      */
     @Override
-    public Integer generateCacheKey() {
-        return Objects.hash(super.generateCacheKey(), getUsername(), getPassword());
+    public byte[] generateCacheKey() {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-512");
+
+            digest.update(super.generateCacheKey());
+            digest.update(getUsername().getBytes());
+            digest.update(getPassword().getBytes());
+
+            return digest.digest();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-512 nicht verfügbar.", e);
+        }
     }
 }

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/PasswordClientRegistrationAuthenticationToken.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/PasswordClientRegistrationAuthenticationToken.java
@@ -2,10 +2,13 @@ package de.bund.bva.isyfact.security.oauth2.client.authentication.token;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 import org.springframework.lang.Nullable;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.util.SerializationUtils;
 
 /**
  * AuthenticationToken holding parameters required for creating a Client to use with Resource Owner Password Credentials Flow authentication.
@@ -54,8 +57,13 @@ public class PasswordClientRegistrationAuthenticationToken extends AbstractClien
             MessageDigest digest = MessageDigest.getInstance(hashAlgorithm);
 
             digest.update(super.generateCacheKey(hashAlgorithm, salt));
-            digest.update(getUsername().getBytes());
-            digest.update(getPassword().getBytes());
+
+            List<String> additionalValues = Arrays.asList(
+                String.valueOf(getUsername()),
+                String.valueOf(getPassword())
+            );
+            byte[] additionalBytes = SerializationUtils.serialize(additionalValues);
+            digest.update(additionalBytes);
 
             return digest.digest();
         } catch (NoSuchAlgorithmException e) {

--- a/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/PasswordClientRegistrationAuthenticationToken.java
+++ b/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/PasswordClientRegistrationAuthenticationToken.java
@@ -49,17 +49,17 @@ public class PasswordClientRegistrationAuthenticationToken extends AbstractClien
      * @return the generated cache key as hash code or null
      */
     @Override
-    public byte[] generateCacheKey(byte[] salt) {
+    public byte[] generateCacheKey(String hashAlgorithm, byte[] salt) {
         try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-512");
+            MessageDigest digest = MessageDigest.getInstance(hashAlgorithm);
 
-            digest.update(super.generateCacheKey(salt));
+            digest.update(super.generateCacheKey(hashAlgorithm, salt));
             digest.update(getUsername().getBytes());
             digest.update(getPassword().getBytes());
 
             return digest.digest();
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("SHA-512 nicht verfügbar.", e);
+            throw new RuntimeException(hashAlgorithm + " nicht verfügbar.", e);
         }
     }
 }

--- a/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerWithLimitedCacheTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerWithLimitedCacheTest.java
@@ -30,9 +30,11 @@ import de.bund.bva.isyfact.security.oauth2.client.authentication.PasswordClientR
  */
 @SpringBootTest
 @TestPropertySource(properties = {
-        "isy.security.cache.ttl=300",
-        "isy.security.cache.maxelements=2",
-        "isy.security.cache.token-expiration-time-offset=10"
+    "isy.security.cache.ttl=300",
+    "isy.security.cache.maxelements=2",
+    "isy.security.cache.token-expiration-time-offset=10",
+    "isy.security.cache.salt-bytes=64",
+    "isy.security.cache.hash-algorithm=SHA-512"
 })
 public class AuthentifizierungsmanagerWithLimitedCacheTest extends AbstractOidcProviderTest {
 
@@ -60,7 +62,6 @@ public class AuthentifizierungsmanagerWithLimitedCacheTest extends AbstractOidcP
 
         when(passwordClientRegistrationAuthenticationProvider.supports(any())).thenCallRealMethod();
         when(passwordClientRegistrationAuthenticationProvider.authenticate(any(Authentication.class))).thenReturn(mockJwt);
-
     }
 
     @Test

--- a/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerWithLimitedCacheTest.java
+++ b/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerWithLimitedCacheTest.java
@@ -1,5 +1,8 @@
 package de.bund.bva.isyfact.security.oauth2.client;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
 import java.lang.reflect.Field;
 import java.time.Instant;
 
@@ -8,7 +11,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
@@ -17,18 +19,11 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import de.bund.bva.isyfact.security.AbstractOidcProviderTest;
 import de.bund.bva.isyfact.security.config.AdditionalCredentials;
 import de.bund.bva.isyfact.security.oauth2.client.authentication.PasswordClientRegistrationAuthenticationProvider;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.clearInvocations;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests the caching of the Authentifizierungsmanager with more authentication attempts than max. cached elements.
@@ -41,7 +36,7 @@ import static org.mockito.Mockito.when;
 })
 public class AuthentifizierungsmanagerWithLimitedCacheTest extends AbstractOidcProviderTest {
 
-    @MockBean
+    @MockitoBean
     private PasswordClientRegistrationAuthenticationProvider passwordClientRegistrationAuthenticationProvider;
 
     @Autowired


### PR DESCRIPTION
* feat: IFS-4812 generate cache keys with sha hashing
* feat: IFS-4812 retrieve bytes with null safety
* refactor: IFS-4812 move salt initialization to IsyOAuth2Authentifizierungsmanager
* feat: IFS-4812 save cache key as base64 encoding
* feat: IFS-4812 store salt bytes and hash algorithm as constants
* docs: IFS-4812 add changelog entry
* feat: IFS-4812 configurable properties for salt bytes and hash algorithm
* docs: IFS-4812 add cache properties to docs