### PR TITLE
[Sprint 135] IFS-4812 Sicheres Hashing für Caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # 5.0.0
 
 ### Breaking Change
-- `IFS-4812`: Verwendung sicherer Hashfunktion für Caching
+- `IFS-4812`: Verwendung sicherer Hashfunktion mit SHA-512 für Caching
+  * Rückgabe eines Byte-Arrays statt eines Integers in der Methode `generateCacheKey` der Klasse `AbstractClientRegistrationAuthenticationToken`
+  * Konfigurierbare Properties für Hashfunktion und Bytegröße des Salts
 
 ### Features
 - `IFS-4577`: Portierung fehlender Tickets aus isyfact-standards


### PR DESCRIPTION
* feat: IFS-4812 generate cache keys with sha hashing
* feat: IFS-4812 retrieve bytes with null safety
* refactor: IFS-4812 move salt initialization to IsyOAuth2Authentifizierungsmanager
* feat: IFS-4812 save cache key as base64 encoding
* feat: IFS-4812 store salt bytes and hash algorithm as constants
* docs: IFS-4812 add changelog entry
* feat: IFS-4812 configurable properties for salt bytes and hash algorithm
* docs: IFS-4812 add cache properties to docs